### PR TITLE
Document contributor branch workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,69 @@ By submitting a pull request, patch, or other contribution to this repository, y
 
 GNU General Public License, version 3 or, at your option, any later version (GPL-3.0-or-later).
 
+## Branch and Deployment Workflow
+
+PluralBridge uses a small branch structure so production stays stable, development stays reviewable, and project work can be previewed before it reaches users.
+
+### Branch roles
+
+#### master
+
+`master` is the production branch.
+
+Rules for `master`:
+
+- `master` only gets merged from `dev`.
+- `master` must never be in a broken state.
+- `master` represents the current public release.
+
+#### dev
+
+`dev` is the stable integration branch for the next release.
+
+Rules for `dev`:
+
+- `dev` only gets merged from project branches.
+- `dev` must never be in a broken state.
+- `dev` is where reviewed project work is collected before release.
+
+#### <project_branch>
+
+A project branch is where active work happens.
+
+Rules for project branches:
+
+- Create project branches from `dev`.
+- Keep each project branch focused on one coherent change.
+- Test the work before merging it back into `dev`.
+- Use clear branch names such as `feature/docs-rendering`, `feature/branching-workflow-docs`, or `patch/image-fix`.
+
+### Development and Deployment Rules
+
+#### Web development
+
+For website and REST service work, use Cloudflare temporary branch previews so changes can be inspected before they merge forward.
+
+**Needs follow-up:** document the exact Cloudflare branch-preview setup and naming rules once the project workflow is finalized.
+
+#### Client application work
+
+For Windows, Linux, macOS, Android, and iOS client work, the release workflow is still TBD.
+
+The project will need an automated build process that runs when client code is committed and pushed.
+
+### Contributor expectations
+
+Contributors should keep changes small, reviewable, and safe.
+
+Expected behavior:
+
+- Start from the correct branch.
+- Keep unrelated changes out of the same pull request.
+- Do not commit generated exports, private data, credentials, local database files, or machine-specific artifacts.
+- Include a clear summary of what changed and how it was tested.
+- Update documentation when behavior, commands, website pages, or user-facing workflows change.
+
 ## Developer Notes
 
 - Preserve existing copyright and license notices.

--- a/website/about.html
+++ b/website/about.html
@@ -34,6 +34,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/developer-workflow.html
+++ b/website/developer-workflow.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Contributor Workflow - PluralBridge</title>
+    <meta name="description" content="PluralBridge contributor branch and deployment workflow for master, dev, project branches, Cloudflare previews, and future client builds.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <meta property="og:title" content="About PluralBridge and Needs of the Many">
+    <meta property="og:description" content="PluralBridge is an independent preservation and continuity project for plural System data.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://thepluralbridge.org/about.html">
+    <meta property="og:image" content="https://thepluralbridge.org/images/background.jpg">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="About PluralBridge and Needs of the Many">
+    <meta name="twitter:description" content="PluralBridge is an independent preservation and continuity project for plural System data.">
+    <meta name="twitter:image" content="https://thepluralbridge.org/images/background.jpg">
+
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="site-header">
+    <div class="header-inner">
+        <a class="brand" href="index.html">
+            <span class="brand-title">PluralBridge</span>
+            <span class="brand-subtitle">Needs of the Many</span>
+        </a>
+        <nav class="nav" aria-label="Main navigation">
+            <a href="export-now.html">Export Now</a>
+            <a href="docs.html">Docs</a>
+            <a href="simply-plural-shutdown.html">Shutdown Info</a>
+            <a href="install.html">Install</a>
+            <a href="run.html">Run</a>
+            <a href="safety.html">Safety</a>
+            <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
+            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+        </nav>
+    </div>
+</header>
+
+<main><section class="hero"><p class="eyebrow">Contributor workflow</p><h1>Branch and deployment workflow</h1><p class="lede">PluralBridge uses a small branch structure so production stays stable, development stays reviewable, and project work can be previewed before it reaches users.</p></section><section class="section card"><h2>Branch roles</h2><h3>master</h3><p><code>master</code> is the production branch.</p><ul><li><code>master</code> only gets merged from <code>dev</code>.</li><li><code>master</code> must never be in a broken state.</li><li><code>master</code> represents the current public release.</li></ul><h3>dev</h3><p><code>dev</code> is the stable integration branch for the next release.</p><ul><li><code>dev</code> only gets merged from project branches.</li><li><code>dev</code> must never be in a broken state.</li><li><code>dev</code> is where reviewed project work is collected before release.</li></ul><h3>&lt;project_branch&gt;</h3><p>A project branch is where active work happens.</p><ul><li>Create project branches from <code>dev</code>.</li><li>Keep each project branch focused on one coherent change.</li><li>Test the work before merging it back into <code>dev</code>.</li><li>Use clear branch names such as <code>feature/docs-rendering</code>, <code>feature/branching-workflow-docs</code>, or <code>patch/image-fix</code>.</li></ul><h2>Development and deployment rules</h2><h3>Web development</h3><p>For website and REST service work, use Cloudflare temporary branch previews so changes can be inspected before they merge forward.</p><p><strong>Needs follow-up:</strong> document the exact Cloudflare branch-preview setup and naming rules once the project workflow is finalized.</p><h3>Client application work</h3><p>For Windows, Linux, macOS, Android, and iOS client work, the release workflow is still TBD.</p><p>The project will need an automated build process that runs when client code is committed and pushed.</p><h2>Contributor expectations</h2><ul><li>Start from the correct branch.</li><li>Keep unrelated changes out of the same pull request.</li><li>Do not commit generated exports, private data, credentials, local database files, or machine-specific artifacts.</li><li>Include a clear summary of what changed and how it was tested.</li><li>Update documentation when behavior, commands, website pages, or user-facing workflows change.</li></ul></section></main>
+
+<footer class="site-footer">
+    <div class="footer-inner">
+        <p>PluralBridge is an independent project by Needs of the Many.</p>
+        <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
+    </div>
+</footer>
+</body>
+</html>

--- a/website/docs.html
+++ b/website/docs.html
@@ -23,6 +23,7 @@
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
             <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -34,6 +34,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -53,6 +53,7 @@
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
             <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/install.html
+++ b/website/install.html
@@ -34,6 +34,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/run.html
+++ b/website/run.html
@@ -34,6 +34,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/safety.html
+++ b/website/safety.html
@@ -34,6 +34,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -35,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="developer-workflow.html">Contributing</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>


### PR DESCRIPTION
## Summary

Documents the PluralBridge contributor branch workflow.

This change adds:

- branch workflow rules to CONTRIBUTING.md
- a public contributor workflow page on the website
- a Contributing link in the website navigation

## Branch model

- master is the production branch.
- master only gets merged from dev.
- master must never be in a broken state.
- dev only gets merged from project branches.
- dev must never be in a broken state.
- project branches are where active work happens.

## Deployment notes

For website and REST service work, contributors should use GitHub pull requests and Cloudflare preview deployments. The exact Cloudflare branch-preview setup still needs to be documented after the workflow is finalized.

For client app work, the build/deployment process is TBD and will need automated builds when client code is committed and pushed.

## Testing

- Verified the branch page exists at website/developer-workflow.html.
- Verified the Contributing nav link was added to public website pages.
- Verified CONTRIBUTING.md was updated with the corrected branch model.
- Verified the feature branch was pushed to origin.