### PR TITLE
Add nontechnical start here path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Project website: https://thepluralbridge.org/
 
+## Regular users: start here
+
+If you are trying to preserve your Simply Plural data and GitHub looks confusing, start with the regular-user guide:
+
+- https://thepluralbridge.org/start-here.html
+
+Downloading the GitHub ZIP gives you the PluralBridge project files. It does not currently give you a finished double-click app installer.
+
+The fastest current user path is:
+
+1. Read the Start Here page.
+2. Continue to Export Now.
+3. Protect your exported files, notes, avatars, backups, and API token.
 
 Welcome to PluralBridge.
 

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,21 @@
+# Start Here
+
+If you downloaded this ZIP because you want to preserve your Simply Plural data, start here.
+
+This ZIP contains PluralBridge project files. It is not currently a normal double-click app installer.
+
+For regular-user instructions, go to:
+https://thepluralbridge.org/start-here.html
+
+If GitHub looks confusing, that is understandable. GitHub is mainly a developer workbench, and PluralBridge needs a clearer path for people who only want to preserve their data.
+
+The current priority is getting Simply Plural data safely exported before the shutdown window closes. Some current steps may still require help from someone comfortable with command-line tools.
+
+Main project website:
+https://thepluralbridge.org/
+
+Export starting point:
+https://thepluralbridge.org/export-now.html
+
+Public GitHub repository:
+https://github.com/needsofmany/PluralBridge

--- a/website/about.html
+++ b/website/about.html
@@ -26,7 +26,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -34,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/docs.html
+++ b/website/docs.html
@@ -14,7 +14,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -26,7 +26,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -34,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -44,7 +44,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>

--- a/website/install.html
+++ b/website/install.html
@@ -26,7 +26,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -34,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/run.html
+++ b/website/run.html
@@ -26,7 +26,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -34,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/safety.html
+++ b/website/safety.html
@@ -26,7 +26,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -34,6 +35,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -27,7 +27,8 @@
             <span class="brand-title">PluralBridge</span>
             <span class="brand-subtitle">Needs of the Many</span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
             <a href="docs.html">Docs</a>
             <a href="simply-plural-shutdown.html">Shutdown Info</a>
@@ -35,6 +36,7 @@
             <a href="run.html">Run</a>
             <a href="safety.html">Safety</a>
             <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
             <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
         </nav>
     </div>

--- a/website/start-here.html
+++ b/website/start-here.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Start Here — PluralBridge</title>
+    <meta name="description" content="Plain-language starting point for regular users who want to preserve Simply Plural data with PluralBridge.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <meta property="og:title" content="Start Here — PluralBridge">
+    <meta property="og:description" content="A plain-language starting point for preserving Simply Plural data with PluralBridge.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://thepluralbridge.org/start-here.html">
+    <meta property="og:image" content="https://thepluralbridge.org/images/background.jpg">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Start Here — PluralBridge">
+    <meta name="twitter:description" content="A plain-language starting point for preserving Simply Plural data with PluralBridge.">
+    <meta name="twitter:image" content="https://thepluralbridge.org/images/background.jpg">
+
+    <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="https://thepluralbridge.org/start-here.html">
+</head>
+<body>
+<header class="site-header">
+    <div class="header-inner">
+        <a class="brand" href="index.html">
+            <span class="brand-title">PluralBridge</span>
+            <span class="brand-subtitle">Needs of the Many</span>
+        </a>
+                <nav class="nav" aria-label="Main navigation">
+            <a href="start-here.html">Start Here</a>
+            <a href="export-now.html">Export Now</a>
+            <a href="docs.html">Docs</a>
+            <a href="simply-plural-shutdown.html">Shutdown Info</a>
+            <a href="install.html">Install</a>
+            <a href="run.html">Run</a>
+            <a href="safety.html">Safety</a>
+            <a href="about.html">About</a>
+            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+        </nav>
+    </div>
+</header>
+
+<main>
+    <section class="hero">
+        <p class="eyebrow">Start here</p>
+        <h1>Preserve your Simply Plural data without having to understand GitHub first.</h1>
+        <p class="lede">
+            PluralBridge helps plural Systems make a local copy of their Simply Plural data before the shutdown window closes. If you aren’t a software developer, click “Export Now” in the blue button below.
+        </p>
+        <div class="actions">
+            <a class="button primary" href="export-now.html">Go to Export Now</a>
+            <a class="button" href="safety.html">Read safety notes</a>
+        </div>
+    </section>
+
+    <section class="section notice">
+        <h2>If you downloaded the GitHub ZIP</h2>
+        <p>
+            The GitHub ZIP contains project files. It is not currently a normal double-click app installer. If you opened the ZIP and felt lost, that reaction makes sense. GitHub is mainly a developer workbench, and PluralBridge needs a clearer path for people who only want to preserve their data.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>What PluralBridge currently is</h2>
+        <ul>
+            <li>A free, open-source preservation project.</li>
+            <li>A way to export user-owned Simply Plural data to local files.</li>
+            <li>A foundation for later viewers, databases, reports, migration tools, and future clients.</li>
+        </ul>
+    </section>
+
+    <section class="section">
+        <h2>What the current export path may require</h2>
+        <ul>
+            <li>Script-based preservation tooling.</li>
+            <li>A Simply Plural API token.</li>
+            <li>Help from someone comfortable with command-line tools, depending on the user.</li>
+        </ul>
+    </section>
+
+    <section class="grid" aria-label="Regular user path">
+        <article class="card">
+            <h3>1. Understand the urgency</h3>
+            <p>Read why exporting matters before the Simply Plural shutdown window closes.</p>
+            <p><a href="simply-plural-shutdown.html">Read shutdown info</a></p>
+        </article>
+
+        <article class="card">
+            <h3>2. Start the export path</h3>
+            <p>Use the export page as the main guide for preserving your data locally.</p>
+            <p><a href="export-now.html">Go to Export Now</a></p>
+        </article>
+
+        <article class="card">
+            <h3>3. Protect your data</h3>
+            <p>Keep tokens, exported JSON files, notes, avatars, and backups private.</p>
+            <p><a href="safety.html">Read Safety</a></p>
+        </article>
+    </section>
+
+    <section class="section">
+        <h2>What you may need</h2>
+        <p>
+            The current export path may require installing software, creating a Simply Plural API token, and running scripts. If those steps are uncomfortable, ask a trusted technical friend or community helper to sit with you. The goal is to preserve your data safely, without requiring every user to become a developer.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Where to go next</h2>
+        <p>
+            The fastest current path is the Export Now page. The GitHub repository remains available for developers, contributors, and anyone who wants to inspect the source code directly.
+        </p>
+        <div class="actions">
+            <a class="button primary" href="export-now.html">Open Export Now</a>
+            <a class="button" href="https://github.com/needsofmany/PluralBridge">Open GitHub</a>
+            <a class="button" href="https://pluralpedia.org/w/PluralBridge">Open Pluralpedia</a>
+        </div>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="footer-inner">
+        <p>PluralBridge is an independent project by Needs of the Many.</p>
+        <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
+    </div>
+</footer>
+</body>
+</html>

--- a/website/style.css
+++ b/website/style.css
@@ -79,7 +79,7 @@ a:hover {
 .nav {
     display: flex;
     flex-wrap: wrap;
-    gap: 14px;
+    gap: 20px;
     align-items: center;
     justify-content: flex-end;
 }
@@ -344,4 +344,33 @@ code {
 .doc-page td code,
 .doc-page th code {
     white-space: nowrap;
+}
+
+
+/* External navigation links */
+.nav a[href^="https://"] {
+    color: #ff8bdc;
+}
+
+.nav a[href^="https://"]:hover {
+    color: #ffb8ee;
+}
+
+.nav .github-link {
+    color: #ff8bdc;
+}
+
+
+/* Primary export navigation link */
+.nav a[href="export-now.html"] {
+    padding: 8px 12px;
+    border-radius: 999px;
+    color: #03111c;
+    background: var(--accent);
+    font-weight: 680;
+}
+
+.nav a[href="export-now.html"]:hover {
+    color: #03111c;
+    background: var(--accent-strong);
 }


### PR DESCRIPTION
Adds a clearer non-technical entry path for users who want to preserve Simply Plural data.

Changes:
- Adds START_HERE.md for users who download the GitHub ZIP.
- Adds website/start-here.html as a plain-language starting point.
- Adds Start Here and Pluralpedia to the top navigation across root website pages.
- Adds README guidance for regular users.
- Styles Export Now as the primary top-level action.
- Styles external top-nav links differently from local site links.

Testing:
- Opened website/start-here.html locally.
- Verified the Start Here page, Export Now button, Pluralpedia link, GitHub link, and top navigation.