### PR TITLE
Release regular-user install clarification

### DIFF
--- a/website/install.html
+++ b/website/install.html
@@ -59,11 +59,13 @@
         <h2>Current requirements</h2>
         <ul>
             <li>A computer where you can install and run command-line software.</li>
-            <li>Git, so the PluralBridge repository can be downloaded or updated.</li>
             <li>Python 3, used by the current export scripts.</li>
             <li>A Bash-compatible shell such as Git Bash on Windows.</li>
             <li>A Simply Plural API token created by the user from inside their Simply Plural account.</li>
         </ul>
+        <p>
+            Git is helpful for developers and trusted helpers who want to download or update the repository directly. If you downloaded the ZIP file from GitHub, you may not need Git for a one-time export.
+        </p>
     </section>
 
     <section class="section notice">


### PR DESCRIPTION
Merges the regular-user install requirement clarification from dev to master.

This release updates the Install page so Git is described as helpful for developers and trusted helpers, rather than as a hard requirement for every regular user doing a one-time ZIP-based export.