### PR TITLE
Add OS-specific install download paths

### DIFF
--- a/website/install.html
+++ b/website/install.html
@@ -81,13 +81,40 @@
     </section>
 
     <section class="section">
-        <h2>Step 2: Have a Bash-compatible shell</h2>
+        <h2>Step 2: Choose your operating system path</h2>
         <p>
-            On Windows, Git Bash is the practical shell for the current workflow. It gives you a Bash-style
-            command window where the export commands can be run.
+            PluralBridge currently runs from a desktop or laptop command line. Choose the path that matches
+            the computer you are using.
+        </p>
+
+        <h3>Windows</h3>
+        <ul>
+            <li>Install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
+            <li>Install Git for Windows from <a href="https://git-scm.com/downloads/win">Git for Windows</a> if you need Git Bash.</li>
+            <li>Use Git Bash for the commands on the Run page.</li>
+        </ul>
+
+        <h3>macOS</h3>
+        <ul>
+            <li>Install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
+            <li>Use Terminal for the commands on the Run page.</li>
+            <li>Install Git from <a href="https://git-scm.com/install/mac">Git for macOS</a> only if you want to clone or update the repository with Git.</li>
+        </ul>
+
+        <h3>Linux</h3>
+        <ul>
+            <li>Install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
+            <li>Use your normal terminal for the commands on the Run page.</li>
+            <li>Install Git using your distribution package manager if needed, or start from <a href="https://git-scm.com/downloads/linux">Git for Linux</a>.</li>
+        </ul>
+
+        <h3>Another desktop or laptop setup</h3>
+        <p>
+            If you use a desktop or laptop setup that is not covered here, contact
+            <a href="mailto:needsofthemany@thepluralbridge.org">needsofthemany@thepluralbridge.org</a>.
         </p>
         <p>
-            On macOS or Linux, the built-in Terminal usually provides a compatible shell.
+            Mobile-only export is not the current PluralBridge path.
         </p>
     </section>
 


### PR DESCRIPTION
## Summary

Adds operating-system-specific install guidance to the public Install page.

## Changes

- Adds separate Windows, macOS, and Linux setup paths.
- Links users directly to official Python and Git download/install pages.
- Clarifies that Git Bash is the Windows command-shell path for the current workflow.
- Adds a fallback contact path for other desktop or laptop setups.
- Adds a `mailto:` link for needsofthemany@thepluralbridge.org.
- Clarifies that mobile-only export is not the current PluralBridge path.

## Notes

This is a website guidance update only. It does not change exporter code.