### PR TITLE
Separate Python and shell install guidance

### DIFF
--- a/website/install.html
+++ b/website/install.html
@@ -71,9 +71,14 @@
     <section class="section">
         <h2>Step 1: Install Python 3</h2>
         <p>
-            Python 3 runs the current PluralBridge export scripts. Install Python 3 from python.org or from
-            another trusted package source for your computer.
+            Python 3 runs the current PluralBridge export scripts. Install Python 3 for the operating system
+            on the computer you will use for the export.
         </p>
+        <ul>
+            <li>Windows: install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
+            <li>macOS: install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
+            <li>Linux: install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
+        </ul>
         <p>
             During installation on Windows, enable the option that adds Python to PATH when it is offered.
             That makes the <code>python</code> command available from the shell.
@@ -81,7 +86,7 @@
     </section>
 
     <section class="section">
-        <h2>Step 2: Choose your operating system path</h2>
+        <h2>Step 2: Choose your command-line path</h2>
         <p>
             PluralBridge currently runs from a desktop or laptop command line. Choose the path that matches
             the computer you are using.
@@ -89,21 +94,18 @@
 
         <h3>Windows</h3>
         <ul>
-            <li>Install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
             <li>Install Git for Windows from <a href="https://git-scm.com/downloads/win">Git for Windows</a> if you need Git Bash.</li>
             <li>Use Git Bash for the commands on the Run page.</li>
         </ul>
 
         <h3>macOS</h3>
         <ul>
-            <li>Install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
             <li>Use Terminal for the commands on the Run page.</li>
             <li>Install Git from <a href="https://git-scm.com/install/mac">Git for macOS</a> only if you want to clone or update the repository with Git.</li>
         </ul>
 
         <h3>Linux</h3>
         <ul>
-            <li>Install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
             <li>Use your normal terminal for the commands on the Run page.</li>
             <li>Install Git using your distribution package manager if needed, or start from <a href="https://git-scm.com/downloads/linux">Git for Linux</a>.</li>
         </ul>


### PR DESCRIPTION
## Summary

Separates Python installation guidance from command-line and shell guidance on the public Install page.

## Changes

- Moves Windows, macOS, and Linux Python download guidance into Step 1.
- Changes Step 2 to focus on the command-line path.
- Leaves Git Bash and Git guidance under the shell/command-line section.
- Keeps the fallback `mailto:` contact path and mobile-only note in Step 2.

## Notes

This is a website guidance update only. It does not change exporter code.