### PR TITLE
Dev

### DIFF
--- a/website/install.html
+++ b/website/install.html
@@ -44,58 +44,103 @@
 <main>
     <section class="hero">
         <p class="eyebrow">Install requirements</p>
-        <h1>Set up the local tools before running the export scripts.</h1>
+        <h1>Set up the local tools you need before running the export.</h1>
         <p class="lede">
-            The current PluralBridge export path is script-based. The goal is a practical local setup that can pull
-            user-owned Simply Plural data into files on the user’s machine.
+            PluralBridge currently uses local scripts. This page explains what to install, what to download,
+            and what to have ready before you move to the Run page.
         </p>
         <div class="actions">
-            <a class="button primary" href="run.html">Next: Run the scripts</a>
-            <a class="button" href="https://github.com/needsofmany/PluralBridge">View source on GitHub</a>
+            <a class="button primary" href="run.html">Next: Run the export</a>
+            <a class="button" href="help-me-export.html">Help me choose a path</a>
+        </div>
+    </section>
+
+    <section class="section notice">
+        <h2>What this page is for</h2>
+        <p>
+            Use this page to get the local setup ready. After this page, you should have Python installed,
+            a Bash-compatible shell available, the PluralBridge files on your computer, and your Simply Plural
+            API token ready to use.
+        </p>
+        <p>
+            This setup keeps the export on your computer. This website does not collect your token or receive
+            your exported Simply Plural data.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 1: Install Python 3</h2>
+        <p>
+            Python 3 runs the current PluralBridge export scripts. Install Python 3 from python.org or from
+            another trusted package source for your computer.
+        </p>
+        <p>
+            During installation on Windows, enable the option that adds Python to PATH when it is offered.
+            That makes the <code>python</code> command available from the shell.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 2: Have a Bash-compatible shell</h2>
+        <p>
+            On Windows, Git Bash is the practical shell for the current workflow. It gives you a Bash-style
+            command window where the export commands can be run.
+        </p>
+        <p>
+            On macOS or Linux, the built-in Terminal usually provides a compatible shell.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 3: Get the PluralBridge files</h2>
+        <p>
+            The PluralBridge files are published on GitHub:
+        </p>
+        <p>
+            <a href="https://github.com/needsofmany/PluralBridge">https://github.com/needsofmany/PluralBridge</a>
+        </p>
+        <p>
+            A trusted technical helper may use Git to clone or update the repository. A regular user doing a
+            one-time export may be able to download the ZIP file from GitHub instead.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 4: Create your Simply Plural API token</h2>
+        <p>
+            The export scripts need a Simply Plural API token created from inside your own Simply Plural account.
+            The token lets the local script read your data so it can save a copy on your computer.
+        </p>
+        <p>
+            Treat the token like a password. Do not post it publicly, commit it to GitHub, or send it to anyone
+            you do not trust with access to your Simply Plural data.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 5: Go to the Run page</h2>
+        <p>
+            When Python, a shell, the PluralBridge files, and your token are ready, continue to the Run page.
+            That page explains how to start the export and what successful output should look like.
+        </p>
+        <div class="actions">
+            <a class="button primary" href="run.html">Next: Run the export</a>
+            <a class="button" href="safety.html">Review safety guidance</a>
         </div>
     </section>
 
     <section class="section">
-        <h2>Current requirements</h2>
+        <h2>Current requirements checklist</h2>
         <ul>
             <li>A computer where you can install and run command-line software.</li>
             <li>Python 3, used by the current export scripts.</li>
             <li>A Bash-compatible shell such as Git Bash on Windows.</li>
+            <li>The PluralBridge files from GitHub.</li>
             <li>A Simply Plural API token created by the user from inside their Simply Plural account.</li>
         </ul>
         <p>
-            Git is helpful for developers and trusted helpers who want to download or update the repository directly. If you downloaded the ZIP file from GitHub, you may not need Git for a one-time export.
-        </p>
-    </section>
-
-    <section class="section notice">
-        <h2>Token boundary</h2>
-        <p>
-            A Simply Plural API token is used only to let the local export scripts read the user’s Simply Plural data.
-            PluralBridge does not ask users to send tokens to this website, upload exported data, or hand private data
-            to Needs of the Many.
-        </p>
-    </section>
-
-    <section class="section">
-        <h2>Windows notes</h2>
-        <p>
-            On Windows, Git Bash is a practical shell for the current workflow. The scripts are intended to run locally,
-            writing exported files into local folders controlled by the user.
-        </p>
-        <p>
-            Later PluralBridge tools may make this process friendlier, but the current preservation priority is getting
-            reliable local exports working while Simply Plural data remains reachable.
-        </p>
-    </section>
-
-    <section class="section">
-        <h2>Where the current files live</h2>
-        <p>
-            The source code and documentation are published in the PluralBridge GitHub repository:
-        </p>
-        <p>
-            <a href="https://github.com/needsofmany/PluralBridge">https://github.com/needsofmany/PluralBridge</a>
+            Git is helpful for developers and trusted helpers who want to download or update the repository directly.
+            If you downloaded the ZIP file from GitHub, you may not need Git for a one-time export.
         </p>
     </section>
 </main>

--- a/website/install.html
+++ b/website/install.html
@@ -81,13 +81,40 @@
     </section>
 
     <section class="section">
-        <h2>Step 2: Have a Bash-compatible shell</h2>
+        <h2>Step 2: Choose your operating system path</h2>
         <p>
-            On Windows, Git Bash is the practical shell for the current workflow. It gives you a Bash-style
-            command window where the export commands can be run.
+            PluralBridge currently runs from a desktop or laptop command line. Choose the path that matches
+            the computer you are using.
+        </p>
+
+        <h3>Windows</h3>
+        <ul>
+            <li>Install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
+            <li>Install Git for Windows from <a href="https://git-scm.com/downloads/win">Git for Windows</a> if you need Git Bash.</li>
+            <li>Use Git Bash for the commands on the Run page.</li>
+        </ul>
+
+        <h3>macOS</h3>
+        <ul>
+            <li>Install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
+            <li>Use Terminal for the commands on the Run page.</li>
+            <li>Install Git from <a href="https://git-scm.com/install/mac">Git for macOS</a> only if you want to clone or update the repository with Git.</li>
+        </ul>
+
+        <h3>Linux</h3>
+        <ul>
+            <li>Install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
+            <li>Use your normal terminal for the commands on the Run page.</li>
+            <li>Install Git using your distribution package manager if needed, or start from <a href="https://git-scm.com/downloads/linux">Git for Linux</a>.</li>
+        </ul>
+
+        <h3>Another desktop or laptop setup</h3>
+        <p>
+            If you use a desktop or laptop setup that is not covered here, contact
+            <a href="mailto:needsofthemany@thepluralbridge.org">needsofthemany@thepluralbridge.org</a>.
         </p>
         <p>
-            On macOS or Linux, the built-in Terminal usually provides a compatible shell.
+            Mobile-only export is not the current PluralBridge path.
         </p>
     </section>
 

--- a/website/install.html
+++ b/website/install.html
@@ -71,9 +71,14 @@
     <section class="section">
         <h2>Step 1: Install Python 3</h2>
         <p>
-            Python 3 runs the current PluralBridge export scripts. Install Python 3 from python.org or from
-            another trusted package source for your computer.
+            Python 3 runs the current PluralBridge export scripts. Install Python 3 for the operating system
+            on the computer you will use for the export.
         </p>
+        <ul>
+            <li>Windows: install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
+            <li>macOS: install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
+            <li>Linux: install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
+        </ul>
         <p>
             During installation on Windows, enable the option that adds Python to PATH when it is offered.
             That makes the <code>python</code> command available from the shell.
@@ -81,7 +86,7 @@
     </section>
 
     <section class="section">
-        <h2>Step 2: Choose your operating system path</h2>
+        <h2>Step 2: Choose your command-line path</h2>
         <p>
             PluralBridge currently runs from a desktop or laptop command line. Choose the path that matches
             the computer you are using.
@@ -89,21 +94,18 @@
 
         <h3>Windows</h3>
         <ul>
-            <li>Install Python 3 from <a href="https://www.python.org/downloads/windows/">Python for Windows</a>.</li>
             <li>Install Git for Windows from <a href="https://git-scm.com/downloads/win">Git for Windows</a> if you need Git Bash.</li>
             <li>Use Git Bash for the commands on the Run page.</li>
         </ul>
 
         <h3>macOS</h3>
         <ul>
-            <li>Install Python 3 from <a href="https://www.python.org/downloads/macos/">Python for macOS</a> if it is not already available.</li>
             <li>Use Terminal for the commands on the Run page.</li>
             <li>Install Git from <a href="https://git-scm.com/install/mac">Git for macOS</a> only if you want to clone or update the repository with Git.</li>
         </ul>
 
         <h3>Linux</h3>
         <ul>
-            <li>Install Python 3 using your distribution package manager if needed, or start from <a href="https://www.python.org/downloads/">Python downloads</a>.</li>
             <li>Use your normal terminal for the commands on the Run page.</li>
             <li>Install Git using your distribution package manager if needed, or start from <a href="https://git-scm.com/downloads/linux">Git for Linux</a>.</li>
         </ul>

--- a/website/run.html
+++ b/website/run.html
@@ -43,61 +43,124 @@
 
 <main>
     <section class="hero">
-        <p class="eyebrow">Run the scripts</p>
-        <h1>Create a local export before the source disappears.</h1>
+        <p class="eyebrow">Run the export</p>
+        <h1>Run the local export and check the files it creates.</h1>
         <p class="lede">
-            The current PluralBridge scripts are designed to export Simply Plural data into local files that remain under
-            the user’s control.
+            This page explains the current PluralBridge command-line export path in plain language.
+            The commands run on your computer and write exported Simply Plural data into local folders.
         </p>
         <div class="actions">
             <a class="button primary" href="safety.html">Review safety notes</a>
-            <a class="button" href="https://github.com/needsofmany/PluralBridge">Open the GitHub repository</a>
+            <a class="button" href="install.html">Back to install steps</a>
         </div>
     </section>
 
     <section class="section notice">
-        <h2>Use the repository instructions as the command source</h2>
+        <h2>Before you start</h2>
         <p>
-            This page gives the public-facing shape of the workflow. The exact commands should be taken from the current
-            PluralBridge repository documentation, because scripts may change as the export path improves.
+            You should already have Python 3, a Bash-compatible shell, the PluralBridge files, and your Simply Plural
+            API token ready. Run these commands from the main PluralBridge folder, the folder that contains
+            <code>README.md</code>, <code>docs</code>, <code>scripts</code>, and <code>website</code>.
+        </p>
+        <p>
+            Your exported files can contain private System information, notes, avatars, timestamps, custom fields,
+            and other sensitive data. Keep the export folder private.
         </p>
     </section>
 
     <section class="section">
-        <h2>Current workflow shape</h2>
+        <h2>Step 1: Open your shell in the PluralBridge folder</h2>
+        <p>
+            Open Git Bash on Windows, or Terminal on macOS or Linux. Change into the folder where you placed the
+            PluralBridge files.
+        </p>
+        <pre><code>cd PluralBridge</code></pre>
+        <p>
+            The folder name may be different if you downloaded a ZIP file or placed the files somewhere else.
+            The important point is that you are in the main folder before running the export commands.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 2: Put your Simply Plural token into the shell</h2>
+        <p>
+            PluralBridge reads your Simply Plural API token from an environment variable named <code>SP_TOKEN</code>.
+            This command lets you paste the token without printing it back onto the screen.
+        </p>
+        <pre><code>read -s -p "Paste Simply Plural token: " SP_TOKEN
+echo
+export SP_TOKEN</code></pre>
+        <p>
+            Check that a token was captured without revealing the token itself:
+        </p>
+        <pre><code>printf 'Token length: %s\n' "${#SP_TOKEN}"</code></pre>
+        <p>
+            A number greater than zero means the shell has a token value. Do not paste the token into screenshots,
+            public issues, chat rooms, pull requests, or shared documents.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 3: Export JSON data</h2>
+        <p>
+            Run the JSON export script:
+        </p>
+        <pre><code>python scripts/python/export_json.py --output-dir exports/json</code></pre>
+        <p>
+            Successful output creates JSON files under <code>exports/json</code>. The exact files depend on your
+            Simply Plural account data and the current script version.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 4: Export avatar images</h2>
+        <p>
+            After <code>members.json</code> exists, run the avatar export script:
+        </p>
+        <pre><code>python scripts/python/export_avatars.py --members-json exports/json/members.json --output-dir exports/member_images</code></pre>
+        <p>
+            Successful output creates image files under <code>exports/member_images</code> when avatar URLs are available.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Step 5: Check what was created</h2>
+        <p>
+            A successful local export should leave private files in local export folders such as:
+        </p>
         <ul>
-            <li>Download or update the PluralBridge repository from GitHub.</li>
-            <li>Create a Simply Plural API token from inside the user’s Simply Plural account.</li>
-            <li>Store the token locally as instructed by the repository documentation.</li>
-            <li>Run the JSON export script.</li>
-            <li>Confirm that JSON files were created in the local export folder.</li>
-            <li>Run avatar and notes export steps where supported.</li>
-            <li>Back up the exported files somewhere private and durable.</li>
+            <li><code>exports/json</code> for exported JSON data.</li>
+            <li><code>exports/member_images</code> for downloaded avatar images.</li>
+            <li>Additional export folders or manifest files as scripts are added or documented.</li>
+        </ul>
+        <p>
+            Back up the <code>exports</code> folder somewhere private and durable. Do not commit it to GitHub.
+        </p>
+    </section>
+
+    <section class="section">
+        <h2>Common warning signs</h2>
+        <ul>
+            <li><code>Token length: 0</code> means the token was not captured by the shell.</li>
+            <li>A missing <code>exports/json</code> folder means the JSON export did not complete successfully.</li>
+            <li>A missing <code>exports/json/members.json</code> file means the avatar export cannot run yet.</li>
+            <li>Authentication or authorization errors usually mean the token is missing, pasted incorrectly, or no longer valid.</li>
         </ul>
     </section>
 
     <section class="section">
-        <h2>Expected local output</h2>
+        <h2>Optional database migration</h2>
         <p>
-            The current export path is intended to create local JSON files and related export folders. Depending on the
-            user’s account data and the current script version, this may include members, groups, front history, custom
-            fields, notes, avatars, timers, polls, friends, chat data, and manifest files.
+            PluralBridge also includes SQL Server migration scripts that can load exported JSON into database tables,
+            constraints, and readable views. That path is mainly for developers, technically comfortable users,
+            validation work, reporting, and future viewer development.
         </p>
     </section>
 
     <section class="section">
-        <h2>Database migration</h2>
+        <h2>Current source instructions</h2>
         <p>
-            PluralBridge also includes SQL Server migration scripts that can turn exported JSON files into database
-            tables, constraints, and readable views. That database path is mainly useful for developers, technically
-            comfortable users, reporting, validation, and future viewer development.
-        </p>
-    </section>
-
-    <section class="section">
-        <h2>Source and current documentation</h2>
-        <p>
-            Use the GitHub repository for the current scripts and exact run instructions:
+            The repository remains the command source for the current scripts and documentation:
         </p>
         <p>
             <a href="https://github.com/needsofmany/PluralBridge">https://github.com/needsofmany/PluralBridge</a>


### PR DESCRIPTION
## Summary

Releases the improved non-technical Install and Run user path.

## Changes

- Updates the Install page from a requirements list into a step-by-step setup path.
- Updates the Run page into a plain-language export procedure.
- Adds clearer output checks and common warning signs.
- Adds operating-system-specific guidance for Windows, macOS, and Linux.
- Moves Python download links into the Python step.
- Keeps shell/Git guidance in the command-line step.
- Adds a mailto contact path for other desktop or laptop setups.
- Clarifies that mobile-only export is not the current PluralBridge path.

## Preview

Preview checked before release.