### PR TITLE
Add official export inspection and normalization probes

### DIFF
--- a/tools/inspect_sp_export.py
+++ b/tools/inspect_sp_export.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Inspect the structure of an official Simply Plural export without printing private values.
+
+This script reports container types, counts, and keys only. It is intended as a safe first pass
+for deciding whether an official Simply Plural export can be normalized into the PluralBridge
+JSON tree shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_PLURALBRIDGE_AREAS = {
+    "members.json": ["members"],
+    "groups.json": ["groups"],
+    "frontHistory.json": ["frontHistory", "front_history", "fronthistory"],
+    "customFields.json": ["customFields", "custom_fields", "customfields"],
+    "customFronts.json": ["customFronts", "custom_fronts", "customfronts"],
+    "privacyBuckets.json": ["privacyBuckets", "privacy_buckets", "privacybuckets"],
+    "polls.json": ["polls"],
+    "timers__automated.json": ["automatedReminders", "automatedTimers", "timersAutomated", "timers__automated"],
+    "timers__repeated.json": ["repeatedReminders", "repeatedRemidners", "timersRepeated", "timers__repeated"],
+    "friends.json": ["friends"],
+    "categories.json": ["channelCategories", "categories", "chatCategories"],
+    "channels.json": ["channels", "chatChannels"],
+    "filters.json": ["filters"],
+    "me.json": ["me"],
+    "user.json": ["users", "user"],
+    "member notes": ["notes", "memberNotes", "member_notes"],
+    "avatar manifest": ["avatarExports", "avatars", "avatar", "avatarUrl", "avatarUuid", "avatarURL"],
+}
+
+SENSITIVE_TOP_LEVEL_KEYS = {
+    "tokens",
+    "securityLogs",
+    "chatMessages",
+    "messages",
+    "friends",
+    "notes",
+    "private",
+    "privateFront",
+    "sharedFront",
+    "usage",
+    "reports",
+    "dataExports",
+    "avatarExports",
+}
+
+SENSITIVE_NESTED_KEYS = {
+    "token",
+    "ip",
+    "message",
+    "note",
+    "url",
+    "avatarUrl",
+    "avatarUuid",
+    "notificationToken",
+}
+
+
+def describe_type(value: Any) -> str:
+    if isinstance(value, dict):
+        return f"dict, keys {len(value)}"
+    if isinstance(value, list):
+        return f"list, count {len(value)}"
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+def sample_keys_from_item(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        return sorted(str(key) for key in value.keys())
+    if isinstance(value, list) and value and isinstance(value[0], dict):
+        return sorted(str(key) for key in value[0].keys())
+    return []
+
+
+def find_keys_recursive(value: Any, wanted: set[str], prefix: str = "") -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key)
+            path = f"{prefix}.{key_text}" if prefix else key_text
+            if key_text in wanted:
+                found.setdefault(key_text, []).append(path)
+            child_found = find_keys_recursive(child, wanted, path)
+            for child_key, paths in child_found.items():
+                found.setdefault(child_key, []).extend(paths)
+    elif isinstance(value, list):
+        for index, child in enumerate(value[:5]):
+            path = f"{prefix}[{index}]" if prefix else f"[{index}]"
+            child_found = find_keys_recursive(child, wanted, path)
+            for child_key, paths in child_found.items():
+                found.setdefault(child_key, []).extend(paths)
+
+    return found
+
+
+def inspect_export(input_path: Path) -> str:
+    raw_text = input_path.read_text(encoding="utf-8-sig")
+    data = json.loads(raw_text)
+
+    lines: list[str] = []
+    lines.append(f"Input file: {input_path}")
+    lines.append(f"File size: {input_path.stat().st_size} bytes")
+    lines.append(f"Top-level type: {describe_type(data)}")
+    lines.append("")
+
+    if isinstance(data, dict):
+        top_keys = sorted(str(key) for key in data.keys())
+        lines.append("Top-level keys:")
+        for key in top_keys:
+            lines.append(f"  - {key}: {describe_type(data[key])}")
+        lines.append("")
+
+        lines.append("Top-level sections and sample nested keys:")
+        for key in top_keys:
+            nested_keys = sample_keys_from_item(data[key])
+            if nested_keys:
+                lines.append(f"  - {key}: sample keys {nested_keys}")
+            else:
+                lines.append(f"  - {key}: no nested object keys sampled")
+        lines.append("")
+    elif isinstance(data, list):
+        lines.append(f"Top-level list count: {len(data)}")
+        lines.append(f"Top-level list sample keys: {sample_keys_from_item(data)}")
+        lines.append("")
+
+    wanted_keys = {candidate for candidates in EXPECTED_PLURALBRIDGE_AREAS.values() for candidate in candidates}
+    recursive_hits = find_keys_recursive(data, wanted_keys)
+
+    lines.append("Likely PluralBridge mappings:")
+    for area, candidates in EXPECTED_PLURALBRIDGE_AREAS.items():
+        matched_paths: list[str] = []
+        for candidate in candidates:
+            matched_paths.extend(recursive_hits.get(candidate, []))
+        if matched_paths:
+            shown_paths = matched_paths[:8]
+            suffix = "" if len(matched_paths) <= 8 else f" ... plus {len(matched_paths) - 8} more"
+            lines.append(f"  - {area}: present at {shown_paths}{suffix}")
+        else:
+            lines.append(f"  - {area}: not found by key-name probe")
+    lines.append("")
+
+    if isinstance(data, dict):
+        known_top_level = set()
+        for candidates in EXPECTED_PLURALBRIDGE_AREAS.values():
+            known_top_level.update(candidates)
+        unknown = [key for key in sorted(str(key) for key in data.keys()) if key not in known_top_level]
+        lines.append("Top-level keys not directly recognized by current probe:")
+        if unknown:
+            for key in unknown:
+                lines.append(f"  - {key}")
+        else:
+            lines.append("  - none")
+        lines.append("")
+
+        lines.append("Sensitive or private-bearing top-level sections present:")
+        sensitive_present = sorted(key for key in data.keys() if str(key) in SENSITIVE_TOP_LEVEL_KEYS)
+        if sensitive_present:
+            for key in sensitive_present:
+                lines.append(f"  - {key}: {describe_type(data[key])}")
+        else:
+            lines.append("  - none detected by key-name probe")
+        lines.append("")
+
+    sensitive_hits = find_keys_recursive(data, SENSITIVE_NESTED_KEYS)
+    lines.append("Sensitive nested key names detected:")
+    if sensitive_hits:
+        for key in sorted(sensitive_hits.keys()):
+            paths = sensitive_hits[key]
+            shown_paths = paths[:8]
+            suffix = "" if len(paths) <= 8 else f" ... plus {len(paths) - 8} more"
+            lines.append(f"  - {key}: present at {shown_paths}{suffix}")
+    else:
+        lines.append("  - none detected by key-name probe")
+    lines.append("")
+
+    lines.append("Preliminary conclusion:")
+    lines.append("  - Official export appears suitable for a PluralBridge normalizer probe if the mapped sections contain usable records.")
+    lines.append("  - Official export must be treated as secret-bearing because token/security/private sections may be present.")
+    lines.append("  - Next useful test is a no-values normalizer dry run that writes section files from top-level arrays only.")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Safely inspect official Simply Plural export structure.")
+    parser.add_argument("input_file", help="Path to the official Simply Plural export JSON file.")
+    parser.add_argument("--report", help="Optional path to write the structural report.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_file)
+    report = inspect_export(input_path)
+
+    if args.report:
+        report_path = Path(args.report)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report + "\n", encoding="utf-8")
+
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/normalize_sp_export.py
+++ b/tools/normalize_sp_export.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Normalize selected top-level sections from an official Simply Plural export.
+
+This first probe writes PluralBridge-like JSON files from top-level arrays only.
+It does not print private values. Console output is limited to file names, counts, and warnings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SECTION_MAP = {
+    "members.json": "members",
+    "groups.json": "groups",
+    "frontHistory.json": "frontHistory",
+    "customFields.json": "customFields",
+    "privacyBuckets.json": "privacyBuckets",
+    "polls.json": "polls",
+    "timers__automated.json": "automatedReminders",
+    "timers__repeated.json": "repeatedReminders",
+    "friends.json": "friends",
+    "categories.json": "channelCategories",
+    "channels.json": "channels",
+}
+
+
+SENSITIVE_TOP_LEVEL_SECTIONS = [
+    "tokens",
+    "securityLogs",
+    "chatMessages",
+    "messages",
+    "private",
+    "privateFront",
+    "sharedFront",
+    "usage",
+    "reports",
+    "dataExports",
+    "avatarExports",
+]
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def item_count(value: Any) -> int:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, dict):
+        return len(value)
+    if value is None:
+        return 0
+    return 1
+
+
+def normalize_user_files(source: dict[str, Any], output_dir: Path, manifest_entries: list[dict[str, Any]]) -> None:
+    users = source.get("users")
+    if isinstance(users, list) and users:
+        write_json(output_dir / "user.json", users[0])
+        manifest_entries.append({"file": "user.json", "source": "users[0]", "count": 1})
+        write_json(output_dir / "me.json", users[0])
+        manifest_entries.append({"file": "me.json", "source": "users[0]", "count": 1})
+    elif isinstance(users, list):
+        write_json(output_dir / "user.json", {})
+        manifest_entries.append({"file": "user.json", "source": "users", "count": 0})
+        write_json(output_dir / "me.json", {})
+        manifest_entries.append({"file": "me.json", "source": "users", "count": 0})
+
+
+def normalize_notes(source: dict[str, Any], output_dir: Path, manifest_entries: list[dict[str, Any]]) -> None:
+    notes = source.get("notes")
+    notes_dir = output_dir / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+
+    if not isinstance(notes, list):
+        manifest_entries.append({"file": "notes/", "source": "notes", "count": 0})
+        return
+
+    for index, note in enumerate(notes, start=1):
+        write_json(notes_dir / f"{index}.json", note)
+
+    manifest_entries.append({"file": "notes/", "source": "notes", "count": len(notes)})
+
+
+def normalize_export(input_path: Path, output_root: Path) -> list[str]:
+    source = load_json(input_path)
+    if not isinstance(source, dict):
+        raise ValueError("Official export root must be a JSON object for this probe.")
+
+    json_dir = output_root / "json"
+    json_dir.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    manifest_entries: list[dict[str, Any]] = []
+
+    lines.append(f"Input file: {input_path}")
+    lines.append(f"Output root: {output_root}")
+    lines.append("")
+    lines.append("Written PluralBridge-shaped files:")
+
+    for output_name, source_key in SECTION_MAP.items():
+        value = source.get(source_key, [])
+        write_json(json_dir / output_name, value)
+        count = item_count(value)
+        manifest_entries.append({"file": output_name, "source": source_key, "count": count})
+        lines.append(f"  - {output_name}: source {source_key}, count {count}")
+
+    normalize_user_files(source, json_dir, manifest_entries)
+    lines.append("  - user.json: source users[0] when present")
+    lines.append("  - me.json: source users[0] when present")
+
+    normalize_notes(source, output_root, manifest_entries)
+    notes_count = len(source.get("notes", [])) if isinstance(source.get("notes"), list) else 0
+    lines.append(f"  - notes/: source notes, count {notes_count}")
+
+    manifest = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "input_file_name": input_path.name,
+        "source_format": "official_simply_plural_export_probe",
+        "entries": manifest_entries,
+    }
+    write_json(json_dir / "manifest.json", manifest)
+    lines.append("  - manifest.json: generated probe manifest")
+    lines.append("")
+
+    lines.append("Sensitive top-level sections intentionally not copied by this first probe:")
+    copied_sources = set(SECTION_MAP.values()) | {"users", "notes"}
+    for key in SENSITIVE_TOP_LEVEL_SECTIONS:
+        if key in source and key not in copied_sources:
+            lines.append(f"  - {key}: present, not copied")
+    lines.append("")
+
+    lines.append("Probe result: wrote files for shape comparison only. Console output contains counts, not private values.")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Normalize official Simply Plural export into a PluralBridge-like folder shape.")
+    parser.add_argument("input_file", help="Path to the official Simply Plural export JSON file.")
+    parser.add_argument("--output-root", default="exports/from_sp_export", help="Output root folder.")
+    args = parser.parse_args()
+
+    lines = normalize_export(Path(args.input_file), Path(args.output_root))
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds early diagnostic tooling for inspecting and normalizing official Simply Plural export files.

This is a probe, not a polished user-facing importer.

What this adds:

- tools/inspect_sp_export.py
  - Inspects official Simply Plural export structure.
  - Reports top-level sections, counts, sample keys, likely PluralBridge mappings, and sensitive/private-bearing sections.
  - Avoids printing private values.

- tools/normalize_sp_export.py
  - Performs a first-pass normalization from official Simply Plural export sections into a PluralBridge-like output tree.
  - Writes shape-comparison files under an output folder such as exports/from_sp_export.
  - Copies core top-level preservation sections only.
  - Leaves sensitive sections such as tokens, security logs, reports, private front state, chat messages, and usage data out of the first probe output.

Initial local probe findings:

- Official export contains major core preservation structures.
- Core counts matched the existing PluralBridge API export for members, front history, custom fields, privacy buckets, friends, categories, channels, user, and me.
- Official export appears to contain token/security/private-bearing sections and must be treated as a secret-bearing backup file.
- Notes are packaged differently between the API export and the official export, so note handling needs additional care before this becomes a production import path.

This branch exists to preserve the diagnostic work and support the next decision about whether PluralBridge should support official-export ingest as a first-class preservation path.