### PR TITLE
Add site-wide export privacy reminder

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -41,6 +41,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">About the project</p>

--- a/website/docs.html
+++ b/website/docs.html
@@ -29,6 +29,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
   <main class="page">
     <section class="hero">
       <h1>PluralBridge Documentation</h1>

--- a/website/docs/developer-guide/rest-api-with-token.html
+++ b/website/docs/developer-guide/rest-api-with-token.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="use-the-simply-plural-rest-api-with-a-token">Use the Simply Plural REST API with a Token</h1>

--- a/website/docs/developer-guide/service-design-working-model.html
+++ b/website/docs/developer-guide/service-design-working-model.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="pluralbridge-service-design-working-model">PluralBridge Service Design Working Model</h1>

--- a/website/docs/developer-guide/sql-server-database-build-and-load.html
+++ b/website/docs/developer-guide/sql-server-database-build-and-load.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="pluralbridge-sql-server-database-build-and-load-guide">PluralBridge SQL Server Database Build and Load Guide</h1>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="pluralbridge-documentation">PluralBridge Documentation</h1>

--- a/website/docs/project/roadmap.html
+++ b/website/docs/project/roadmap.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="pluralbridge-roadmap-and-post-release-task-list">PluralBridge Roadmap and Post-Release Task List</h1>

--- a/website/docs/start-here/simply-plural-shutdown.html
+++ b/website/docs/start-here/simply-plural-shutdown.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="simply-plural-shutdown-and-data-preservation">Simply Plural Shutdown and Data Preservation</h1>

--- a/website/docs/user-guide/create-simply-plural-api-token.html
+++ b/website/docs/user-guide/create-simply-plural-api-token.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="create-a-simply-plural-api-token">Create a Simply Plural API Token</h1>

--- a/website/docs/user-guide/export-avatars.html
+++ b/website/docs/user-guide/export-avatars.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="export-simply-plural-member-avatars">Export Simply Plural Member Avatars</h1>

--- a/website/docs/user-guide/preserve-your-data.html
+++ b/website/docs/user-guide/preserve-your-data.html
@@ -29,6 +29,12 @@
         </nav>
     </div>
 </header>
+
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
 <main class="page">
   <article class="card doc-page">
 <h1 id="preserve-your-simply-plural-data">Preserve Your Simply Plural Data</h1>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -41,6 +41,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Export now</p>

--- a/website/help-me-export.html
+++ b/website/help-me-export.html
@@ -42,6 +42,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Help me export</p>

--- a/website/index.html
+++ b/website/index.html
@@ -59,6 +59,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Simply Plural data preservation</p>

--- a/website/install.html
+++ b/website/install.html
@@ -41,6 +41,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Install requirements</p>

--- a/website/run.html
+++ b/website/run.html
@@ -41,6 +41,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Run the export</p>

--- a/website/safety.html
+++ b/website/safety.html
@@ -41,6 +41,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Safety and privacy</p>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -42,6 +42,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Simply Plural shutdown</p>

--- a/website/start-here.html
+++ b/website/start-here.html
@@ -42,6 +42,12 @@
     </div>
 </header>
 
+
+<div class="privacy-banner" role="note">
+    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+</div>
+
+
 <main>
     <section class="hero">
         <p class="eyebrow">Start here</p>

--- a/website/style.css
+++ b/website/style.css
@@ -374,3 +374,22 @@ code {
     color: #03111c;
     background: var(--accent-strong);
 }
+
+.privacy-banner {
+    width: min(var(--max-width), calc(100% - 32px));
+    margin: 18px auto 0;
+    padding: 12px 16px;
+    border: 1px solid rgba(255, 210, 122, 0.48);
+    border-radius: 18px;
+    color: var(--text-muted);
+    background: rgba(84, 56, 13, 0.34);
+    font-size: 0.95rem;
+}
+
+.privacy-banner strong {
+    color: var(--warning);
+}
+
+.privacy-banner + main {
+    padding-top: 28px;
+}


### PR DESCRIPTION
Adds a small site-wide privacy reminder banner to the public PluralBridge website.

Why this matters:

- Official Simply Plural export files may contain sensitive account, token, note, message, friend, avatar, and System data.
- Users may not realize that an export file should be treated as a private backup rather than an ordinary support attachment.
- The warning belongs near the top of every public page so users see it regardless of which page they land on first.

What changed:

- Added a privacy reminder banner below the site header on all public HTML pages.
- Added CSS for the banner in website/style.css.
- Tightened the spacing between the banner and main page content after local browser review.

The banner text is intentionally calm and practical:

Privacy reminder: Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.