### PR TITLE
Improve mobile website navigation

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -91,8 +91,8 @@ a:hover {
 
 .nav {
     display: flex;
-    flex-wrap: nowrap;
-    gap: 14px;
+    flex-wrap: wrap;
+    gap: 10px 12px;
     align-items: center;
     justify-content: flex-end;
 }
@@ -300,7 +300,7 @@ code {
 
 
 
-\n.site-footer {
+.site-footer {
     border-top: 1px solid var(--line-soft);
     background: rgba(5, 8, 13, 0.82);
 }
@@ -321,10 +321,28 @@ code {
     .header-inner {
         align-items: flex-start;
         flex-direction: column;
+        gap: 18px;
     }
 
     .nav {
-        justify-content: flex-start;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+        width: 100%;
+        justify-content: stretch;
+    }
+
+    .nav a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 42px;
+        padding: 9px 10px;
+        border: 1px solid var(--line-soft);
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.04);
+        text-align: center;
+        white-space: normal;
     }
 
     .hero {


### PR DESCRIPTION
## Summary

This PR improves the public website navigation so it behaves better on narrow screens and mobile devices.

Changes include:

- allowing the desktop navigation to wrap instead of forcing one long row
- changing the mobile navigation into a two-column button grid
- improving mobile tap targets and readability
- preserving the existing navigation links and page structure
- fixing a stray `\n.site-footer` typo in `website/style.css`

## Verification

Locally previewed with:

`python -m http.server 8000 --directory website`

Checked:

- desktop/narrow browser layout
- mobile-sized browser layout
- real phone preview at local LAN URL

The mobile layout was confirmed readable, tappable, and visually clean on a phone.