### PR TITLE
Add mobile privacy reminder toggle and v0.5.0 task record

### DIFF
--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -6,6 +6,29 @@ Tags are listed in reverse chronological order so the latest project changes app
 
 ---
 
+## v0.5.0 — Mobile navigation and privacy reminder usability
+
+### Major tasks completed
+
+- Added the first contributor-ready starter Issues for developer-community outreach.
+- Added and labeled starter Issues for synthetic fixtures, export validation, SQLite schema drafting, non-technical export guidance, and documentation/accessibility review.
+- Added a developer landing Discussion pointing contributors to scoped starter Issues and privacy-safe contribution boundaries.
+- Improved public website navigation for narrow screens and mobile devices.
+- Changed mobile navigation into a two-column tappable grid.
+- Preserved the existing desktop navigation and page structure while allowing better wrapping behavior.
+- Added a mobile privacy reminder toggle so the privacy warning starts compact on phones and can be expanded when needed.
+- Kept the full privacy warning visible on desktop.
+- Added `website/privacy-banner.js` for the mobile privacy reminder toggle.
+- Previewed website changes locally and on a real phone before release.
+
+### Notes
+
+This release is a visible website usability release. It improves the mobile path before adding the later Contact/Support page, so users can navigate the site more clearly on phones while still seeing the privacy reminder and having access to the full warning text.
+
+The developer-outreach foundation now includes scoped starter Issues and a GitHub Discussion landing point, with the same safety boundary: contributors should use synthetic examples, redacted descriptions, and public-safe fixtures only.
+
+---
+
 ## v0.4.2 — GitHub Discussions and public project links
 
 ### Major tasks completed
@@ -293,7 +316,7 @@ This tag represents the initial public foundation: export-first preservation, lo
 
 ---
 
-## Current post-v0.4.1 follow-up queue
+## Current post-v0.5.0 follow-up queue
 
 ### Public site and user-path verification
 
@@ -324,7 +347,7 @@ This tag represents the initial public foundation: export-first preservation, lo
 - Add a release checklist.
 - Decide whether to add `CHANGELOG.md`.
 - Keep `CONTRIBUTING.md` and `website/developer-workflow.html` aligned as contributor workflow evolves.
-- Plan a later dropdown/grouped navigation branch if the flat nav becomes too crowded.
+- Revisit dropdown/grouped navigation later if the flat desktop nav becomes too crowded again.
 
 ### Regular-user tooling
 
@@ -359,17 +382,17 @@ This tag represents the initial public foundation: export-first preservation, lo
 
 ---
 
-## Current contributor-ready issue planning
+## Current contributor-ready outreach state
 
-These are candidate starter Issues for developer-community outreach. They should be created only when each item has a clear scope, privacy-safe boundaries, and a synthetic-data path.
+The first starter Issues and developer landing Discussion have been created for developer-community outreach. Further Issues should still be created only when each item has a clear scope, privacy-safe boundaries, and a synthetic-data path.
 
-### Candidate starter Issues
+### Current starter Issues
 
-- Add synthetic export fixture set for tests and examples.
-- Add export validation summary output.
-- Draft initial SQLite schema for local/offline preserved data.
-- Improve non-technical export success/failure guidance.
-- Review documentation for accessibility and plain-language clarity.
+- #38 — Add synthetic export fixture set for tests and examples.
+- #39 — Add export validation summary output.
+- #40 — Draft initial SQLite schema for local/offline preserved data.
+- #41 — Improve non-technical export success/failure guidance.
+- #42 — Review documentation for accessibility and plain-language clarity.
 
 ### Privacy and data-safety boundary
 
@@ -377,4 +400,4 @@ All contributor-ready Issues should assume synthetic examples, redacted descript
 
 ### Outreach sequencing
 
-Developer-community outreach should come before the Contact/Support page and navigation/mobile repair work. The Contact/Support page and navbar/mobile cleanup are the next focused website task after the first developer outreach pass.
+Developer-community outreach should come before the Contact/Support page. Mobile navigation repair has now been addressed in the v0.5.0 work. The Contact/Support page remains the next focused website task after developer outreach stabilizes.

--- a/website/about.html
+++ b/website/about.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -118,5 +119,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/developer-workflow.html
+++ b/website/developer-workflow.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -236,5 +237,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/docs.html
+++ b/website/docs.html
@@ -35,8 +35,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -85,5 +86,6 @@
       </ul>
     </section>
   </main>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -123,5 +124,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/help-me-export.html
+++ b/website/help-me-export.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -158,5 +159,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -65,8 +65,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -136,5 +137,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/install.html
+++ b/website/install.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -191,5 +192,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/privacy-banner.js
+++ b/website/privacy-banner.js
@@ -1,0 +1,24 @@
+(function () {
+    function setExpanded(banner, button, expanded) {
+        banner.classList.toggle("is-collapsed", !expanded);
+        button.setAttribute("aria-expanded", expanded ? "true" : "false");
+        button.textContent = expanded ? "Hide full reminder" : "Show full reminder";
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".privacy-banner").forEach(function (banner) {
+            var button = banner.querySelector(".privacy-banner-toggle");
+
+            if (!button) {
+                return;
+            }
+
+            setExpanded(banner, button, false);
+
+            button.addEventListener("click", function () {
+                var expanded = button.getAttribute("aria-expanded") === "true";
+                setExpanded(banner, button, !expanded);
+            });
+        });
+    });
+})();

--- a/website/run.html
+++ b/website/run.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -185,5 +186,6 @@ export SP_TOKEN</code></pre>
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/safety.html
+++ b/website/safety.html
@@ -47,8 +47,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -121,5 +122,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -48,8 +48,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -130,5 +131,6 @@
     <p>PluralBridge is an independent project by Needs of the Many.</p>
     <p>No affiliation with Simply Plural, Apparyllis, or the Simply Plural development team.</p>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/start-here.html
+++ b/website/start-here.html
@@ -48,8 +48,9 @@
 </header>
 
 
-<div class="privacy-banner" role="note">
-    <strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.
+<div class="privacy-banner is-collapsed" role="note">
+    <div class="privacy-banner-text"><strong>Privacy reminder:</strong> Simply Plural exports may contain sensitive account, token, note, message, friend, avatar, and System data. Treat export files as private backups. Do not post them publicly or attach them to support requests.</div>
+    <button type="button" class="privacy-banner-toggle" aria-expanded="false">Show full reminder</button>
 </div>
 
 
@@ -138,5 +139,6 @@
         <p>PluralBridge is not affiliated with Simply Plural or Apparyllis.</p>
     </div>
 </footer>
+    <script src="privacy-banner.js"></script>
 </body>
 </html>

--- a/website/style.css
+++ b/website/style.css
@@ -345,6 +345,20 @@ code {
         white-space: normal;
     }
 
+    .privacy-banner {
+        font-size: 0.9rem;
+        line-height: 1.45;
+    }
+
+    .privacy-banner.is-collapsed .privacy-banner-text {
+        max-height: calc(2 * 1.45em);
+        overflow: hidden;
+    }
+
+    .privacy-banner .privacy-banner-toggle {
+        display: inline-block;
+    }
+
     .hero {
         padding: 28px;
     }
@@ -435,6 +449,24 @@ code {
 
 .privacy-banner strong {
     color: var(--warning);
+}
+
+.privacy-banner-toggle {
+    display: none;
+    appearance: none;
+    margin-top: 8px;
+    border: 1px solid rgba(255, 210, 122, 0.62);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--warning);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9rem;
+    padding: 6px 10px;
+}
+
+.privacy-banner-toggle:hover {
+    background: rgba(255, 255, 255, 0.14);
 }
 
 .privacy-banner + main {


### PR DESCRIPTION
## Summary

This PR adds a mobile privacy reminder toggle and records the pending v0.5.0 release work.

Changes include:

- mobile privacy banner starts compact on phones
- users can tap Show full reminder / Hide full reminder
- full privacy warning remains visible on desktop
- `website/privacy-banner.js` added for the toggle behavior
- all top-level website pages updated consistently
- `TAG_TASKS.md` updated with pending v0.5.0 release notes
- follow-up queue refreshed to `Current post-v0.5.0`

## Verification

Locally previewed with:

`python -m http.server 8000 --directory website`

Checked:

- desktop browser: full privacy warning remains visible with no toggle button
- phone browser: compact warning appears with Show full reminder button
- phone browser: expand/collapse works
- phone browser: navigating to another page starts the warning compact again
- multiple pages confirmed visually on phone