### PR TITLE
Release v0.5.2 website menu restructure

### DIFF
--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -6,6 +6,27 @@ Tags are listed in reverse chronological order so the latest project changes app
 
 ---
 
+## v0.5.2 — Website menu restructure
+
+### Major tasks completed
+
+- Restructured the top-level public website navigation into grouped menus.
+- Added `Home` as a visible top-level navigation item.
+- Kept `Start Here` and `Export Now` as direct top-level navigation items.
+- Grouped documentation and user-flow pages under `Guides`.
+- Grouped Discussions, Pluralpedia, Mastodon, and GitHub under `Community`.
+- Converted `About` into a grouped menu with `About PluralBridge` and a disabled `Contact Us` coming-soon placeholder.
+- Added active navigation states for top-level pages and guide submenu items.
+- Added mobile styling so dropdown menu labels behave like centered navigation buttons.
+- Added `website/site-menu.js` so opening one dropdown closes any other open dropdown.
+- Previewed the grouped navigation locally in desktop browser and on Android before release.
+
+### Notes
+
+This release improves the public website navigation before the later Contact/Support page work. The Contact Us item is intentionally present as a disabled placeholder; the actual Contact/Support page is deferred to a separate feature branch.
+
+---
+
 ## v0.5.1 — Social preview image update
 
 ### Major tasks completed
@@ -331,7 +352,7 @@ This tag represents the initial public foundation: export-first preservation, lo
 
 ---
 
-## Current post-v0.5.1 follow-up queue
+## Current post-v0.5.2 follow-up queue
 
 ### Public site and user-path verification
 
@@ -363,7 +384,6 @@ This tag represents the initial public foundation: export-first preservation, lo
 - Add a release checklist.
 - Decide whether to add `CHANGELOG.md`.
 - Keep `CONTRIBUTING.md` and `website/developer-workflow.html` aligned as contributor workflow evolves.
-- Revisit dropdown/grouped navigation later if the flat desktop nav becomes too crowded again.
 
 ### Regular-user tooling
 

--- a/website/about.html
+++ b/website/about.html
@@ -30,18 +30,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary>Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary data-current="section">About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html" aria-current="page">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -120,5 +138,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/developer-workflow.html
+++ b/website/developer-workflow.html
@@ -29,19 +29,37 @@
                 <span class="brand-subtitle">Needs of the Many</span>
             </span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html" aria-current="page">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -238,5 +256,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/docs.html
+++ b/website/docs.html
@@ -18,18 +18,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html" aria-current="page">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -87,5 +105,6 @@
     </section>
   </main>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -30,18 +30,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
-            <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <a href="export-now.html" aria-current="page">Export Now</a>
+            <details class="nav-menu">
+                <summary>Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -125,5 +143,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/help-me-export.html
+++ b/website/help-me-export.html
@@ -30,18 +30,37 @@
                 <span class="brand-subtitle">Needs of the Many</span>
             </span>
         </a>
-        <nav class="nav" aria-label="Main navigation">
+                <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -160,5 +179,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -48,18 +48,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html" aria-current="page">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary>Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -138,5 +156,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/install.html
+++ b/website/install.html
@@ -30,18 +30,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html" aria-current="page">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -193,5 +211,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/run.html
+++ b/website/run.html
@@ -30,18 +30,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html" aria-current="page">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -187,5 +205,6 @@ export SP_TOKEN</code></pre>
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/safety.html
+++ b/website/safety.html
@@ -30,18 +30,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html" aria-current="page">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -123,5 +141,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -31,18 +31,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
+            <a href="index.html">Home</a>
             <a href="start-here.html">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary data-current="section">Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html" aria-current="page">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -132,5 +150,6 @@
     <p>No affiliation with Simply Plural, Apparyllis, or the Simply Plural development team.</p>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/site-menu.js
+++ b/website/site-menu.js
@@ -1,0 +1,17 @@
+(function () {
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".nav-menu").forEach(function (menu) {
+            menu.addEventListener("toggle", function () {
+                if (!menu.open) {
+                    return;
+                }
+
+                document.querySelectorAll(".nav-menu[open]").forEach(function (otherMenu) {
+                    if (otherMenu !== menu) {
+                        otherMenu.open = false;
+                    }
+                });
+            });
+        });
+    });
+})();

--- a/website/start-here.html
+++ b/website/start-here.html
@@ -31,18 +31,36 @@
             </span>
         </a>
                 <nav class="nav" aria-label="Main navigation">
-            <a href="start-here.html">Start Here</a>
+            <a href="index.html">Home</a>
+            <a href="start-here.html" aria-current="page">Start Here</a>
             <a href="export-now.html">Export Now</a>
-            <a href="docs.html">Docs</a>
-            <a href="simply-plural-shutdown.html">Shutdown Info</a>
-            <a href="install.html">Install</a>
-            <a href="run.html">Run</a>
-            <a href="safety.html">Safety</a>
-            <a href="about.html">About</a>
-            <a href="developer-workflow.html">Contributing</a>
-            <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
-            <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
-            <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+            <details class="nav-menu">
+                <summary>Guides</summary>
+                <div class="nav-menu-panel">
+                    <a href="docs.html">Documentation Home</a>
+                    <a href="install.html">Install</a>
+                    <a href="run.html">Run</a>
+                    <a href="safety.html">Safety</a>
+                    <a href="developer-workflow.html">Contributing</a>
+                    <a href="simply-plural-shutdown.html">Shutdown Info</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>Community</summary>
+                <div class="nav-menu-panel">
+                    <a href="https://github.com/needsofmany/PluralBridge/discussions">Discussions</a>
+                    <a href="https://pluralpedia.org/w/PluralBridge">Pluralpedia</a>
+                    <a href="https://mastodon.social/@needsofthemany">Mastodon</a>
+                    <a class="github-link" href="https://github.com/needsofmany/PluralBridge">GitHub</a>
+                </div>
+            </details>
+            <details class="nav-menu">
+                <summary>About</summary>
+                <div class="nav-menu-panel">
+                    <a href="about.html">About PluralBridge</a>
+                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                </div>
+            </details>
         </nav>
     </div>
 </header>
@@ -140,5 +158,6 @@
     </div>
 </footer>
     <script src="privacy-banner.js"></script>
+    <script src="site-menu.js"></script>
 </body>
 </html>

--- a/website/style.css
+++ b/website/style.css
@@ -104,6 +104,103 @@ a:hover {
     white-space: nowrap;
 }
 
+.nav summary {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    cursor: pointer;
+    list-style: none;
+}
+
+.nav summary::-webkit-details-marker {
+    display: none;
+}
+
+.nav summary::after {
+    content: " ▾";
+    color: var(--text-soft);
+}
+
+.nav-menu {
+    position: relative;
+}
+
+.nav-menu-panel {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 10px);
+    min-width: 220px;
+    padding: 10px;
+    border: 1px solid var(--line-soft);
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.98);
+    box-shadow: var(--shadow-soft);
+    z-index: 20;
+}
+
+.nav-menu[open] .nav-menu-panel {
+    display: grid;
+    gap: 8px;
+}
+
+.nav-menu-panel a[aria-current="page"] {
+    color: var(--text-main);
+    font-weight: 720;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    text-decoration: none;
+}
+
+.nav-menu-panel a[aria-current="page"]::before {
+    content: "•";
+    color: var(--accent);
+    font-size: 1.2rem;
+    line-height: 1;
+    font-weight: 900;
+    flex: 0 0 auto;
+}
+
+.nav-menu-disabled {
+    display: block;
+    padding: 7px 9px;
+    border-radius: 10px;
+    color: var(--text-soft);
+    font-size: 0.9rem;
+    cursor: default;
+}
+
+.nav-menu-note {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+}
+
+.nav-menu-panel a {
+    display: block;
+    padding: 7px 9px;
+    border-radius: 10px;
+}
+
+.nav > a[aria-current="page"],
+.nav summary[data-current="section"] {
+    color: var(--text-main);
+    font-weight: 720;
+}
+
+.nav > a[aria-current="page"],
+.nav summary[data-current="section"] {
+    text-decoration: underline;
+    text-underline-offset: 6px;
+    text-decoration-thickness: 2px;
+}
+
+.nav a[href="export-now.html"][aria-current="page"] {
+    outline: 2px solid rgba(255, 255, 255, 0.72);
+    outline-offset: 2px;
+}
+
 .nav a:hover {
     color: var(--text-main);
 }
@@ -332,7 +429,8 @@ code {
         justify-content: stretch;
     }
 
-    .nav a {
+    .nav a,
+    .nav summary {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -343,6 +441,18 @@ code {
         background: rgba(255, 255, 255, 0.04);
         text-align: center;
         white-space: normal;
+    }
+
+    .nav-menu {
+        width: 100%;
+    }
+
+    .nav-menu-panel {
+        left: 0;
+        right: 0;
+        top: calc(100% + 8px);
+        width: 100%;
+        min-width: 0;
     }
 
     .privacy-banner {


### PR DESCRIPTION
## Summary

This release publishes the website menu restructure currently on dev.

## Changes

- Restructures the top-level public website navigation into grouped menus.
- Adds Home as a visible top-level navigation item.
- Keeps Start Here and Export Now as direct top-level navigation items.
- Groups documentation and user-flow pages under Guides.
- Groups Discussions, Pluralpedia, Mastodon, and GitHub under Community.
- Converts About into a grouped menu with About PluralBridge and a disabled Contact Us coming-soon placeholder.
- Adds active navigation states for top-level pages and guide submenu items.
- Adds mobile styling so dropdown labels behave like centered navigation buttons.
- Adds site-menu.js so opening one dropdown closes any other open dropdown.
- Documents the v0.5.2 release in TAG_TASKS.md.

## Notes

Contact Us is intentionally shown as a coming-soon placeholder. The actual Contact/Support page will be implemented in a separate feature branch.