### PR TITLE
Merge Azure SQL cloud-readiness proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@ database/tracking/
 database/bash/
 database/targeting/prop_candidate/private_export/json/
 database/targeting/prop_candidate_fail_*/
+
+# Cloud-readiness local/transient artifacts
+database/targeting/prop_candidate/cloud/*_tmp/
+database/targeting/prop_candidate/cloud/*.tmp
+database/targeting/prop_candidate/cloud/*.log
+database/targeting/prop_candidate/cloud/*.local.txt
+database/targeting/prop_candidate/cloud/**/*.json
+database/targeting/prop_candidate/cloud/**/*.jsonl

--- a/database/bash/prop_candidiate/cloud/cloud_step_015_inspect_local_script_for_azure.sh
+++ b/database/bash/prop_candidiate/cloud/cloud_step_015_inspect_local_script_for_azure.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+echo "CLOUD STEP 15 INSPECTION START"
+src="database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql"
+out="database/targeting/prop_candidate/cloud/cloud_step_015_local_script_azure_inspection.txt"
+tmpdir="database/targeting/prop_candidate/cloud/cloud_step_015_tmp"
+rm -rf "$tmpdir"
+mkdir -p "$tmpdir"
+rm -f "$out"
+if [ ! -f "$src" ]
+then
+    echo "SOURCE_MISSING=$src"
+    exit 1
+fi
+echo "SOURCE=$src" | tee -a "$out"
+echo "SOURCE_SHA256=$(sha256sum "$src" | awk '{print toupper($1)}')" | tee -a "$out"
+echo "SOURCE_LINES=$(wc -l < "$src" | tr -d ' ')" | tee -a "$out"
+echo "" | tee -a "$out"
+report_pattern()
+{
+    label="$1"
+    pattern="$2"
+    safe_label="$(printf "%s" "$label" | tr " /" "__" | tr -cd "A-Za-z0-9_")"
+    hitfile="$tmpdir/$safe_label.txt"
+    if grep -nE "$pattern" "$src" > "$hitfile"
+    then
+        count="$(wc -l < "$hitfile" | tr -d ' ')"
+    else
+        count="0"
+    fi
+    echo "CHECK=$label COUNT=$count" | tee -a "$out"
+    if [ "$count" != "0" ]
+    then
+        sed -n "1,20p" "$hitfile" | tee -a "$out"
+    fi
+    echo "" | tee -a "$out"
+}
+report_pattern "Dead database reference" "PluralBridge_RebuildScratch"
+report_pattern "Local repeatbuild database reference" "PluralBridge_RepeatBuild"
+report_pattern "Prequel reference" "PluralBridge-Prequel"
+report_pattern "Preop reference" "PluralBridge_Preop"
+report_pattern "USE statement" "^[[:space:]]*USE[[:space:]]+"
+report_pattern "CREATE DATABASE statement" "CREATE[[:space:]]+DATABASE"
+report_pattern "DROP DATABASE statement" "DROP[[:space:]]+DATABASE"
+report_pattern "ALTER DATABASE statement" "ALTER[[:space:]]+DATABASE"
+report_pattern "File path or filegroup option" "FILENAME|FILEGROUP|TEXTIMAGE_ON|ON[[:space:]]+PRIMARY"
+report_pattern "Single user multi user rollback option" "SINGLE_USER|MULTI_USER|ROLLBACK[[:space:]]+IMMEDIATE"
+report_pattern "SQLCMD directive" "^[[:space:]]*:"
+report_pattern "SQLCMD variable token" "\\$\\([A-Za-z0-9_]+\\)"
+report_pattern "Bulk external file operation" "BULK[[:space:]]+INSERT|OPENROWSET|xp_cmdshell|sp_configure"
+report_pattern "Private JSON path leak" "private_export/json|\\.json"
+report_pattern "GO batch separator" "^[[:space:]]*GO[[:space:]]*$"
+rm -rf "$tmpdir"
+echo "AUDIT_FILE=$out"
+echo "CLOUD_STEP_015_INSPECTION_COMPLETE"
+echo "CLOUD STEP 15 INSPECTION END"

--- a/database/targeting/prop_candidate/cloud/cloud_step_014a_branch_decision_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_014a_branch_decision_audit.md
@@ -1,0 +1,30 @@
+# Cloud Readiness Branch Decision Audit
+
+Date: 2026-06-06 PT
+
+## Decision
+
+Cloud-readiness work will proceed on a new feature branch instead of continuing directly on feature/table-normalization-plan.
+
+The new branch is logical branch #2 for currently unmerged feature work.
+
+## Logical branch ordering
+
+- Logical branch #1: feature/table-normalization-plan
+- Logical branch #2: feature/002-cloud-readiness
+
+Logical branch #1 is complete for its current scope, committed, and pushed. It has not yet been merged to dev or master.
+
+Logical branch #1 is intended to be the first branch merged when the unmerged feature branches are integrated.
+
+Logical branch #2 starts from the same green checkpoint HEAD and records Azure/cloud-readiness work separately.
+
+## Starting checkpoint
+
+- Starting HEAD: 1f04f24 Add structure audit for private JSON export
+- Prior green private export checkpoint: database/targeting/prop_candidate/private_export/private_export_step_004_green_checkpoint.md
+- Validated local 1-6 repeat-build script: database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql
+
+## Boundary
+
+This note records branch governance only. It does not change SQL Server, Azure SQL, private JSON payloads, or generated export data.

--- a/database/targeting/prop_candidate/cloud/cloud_step_014b_gitignore_policy_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_014b_gitignore_policy_audit.md
@@ -1,0 +1,15 @@
+# Cloud Readiness Gitignore Policy Audit
+
+Date: 2026-06-06 PT
+
+## Decision
+
+The cloud-readiness branch will track safe planning, audit, manifest, checkpoint, shell, PowerShell, and SQL candidate artifacts.
+
+The branch will not track transient cloud scratch folders, temporary files, local logs, or JSON/JSONL payload files under the cloud candidate folder.
+
+Private export JSON remains ignored separately through the existing database/targeting/prop_candidate/private_export/json/ rule.
+
+## Boundary
+
+This change affects repository hygiene only. It does not touch SQL Server, Azure SQL, or private JSON payload data.

--- a/database/targeting/prop_candidate/cloud/cloud_step_015_inspection_checkpoint.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_015_inspection_checkpoint.md
@@ -1,0 +1,35 @@
+# Cloud Step 15 Inspection Checkpoint
+
+Date: 2026-06-06 PT
+
+## Result
+
+Cloud Step 15 completed as a read-only inspection of the validated local 1-6 repeat-build script.
+
+Hard-stop checks passed:
+
+- Dead database reference count: 0
+- Private JSON path leak count: 0
+
+Expected local-script findings were present:
+
+- Local repeatbuild database reference count: 9
+- PluralBridge-Prequel reference count: 25
+- USE statement count: 3
+- DROP DATABASE statement count: 1
+- ALTER DATABASE statement count: 3
+- SINGLE_USER / MULTI_USER / ROLLBACK option count: 2
+- GO batch separator count: 15
+
+No SQL Server or Azure SQL execution occurred in this step.
+
+## Interpretation
+
+The validated local script is not suitable for direct Azure SQL execution because it includes local repeat-build reset logic, master database context, USE statements, and references to PluralBridge-Prequel as the source database.
+
+The next cloud step should generate an Azure candidate as a target-database script derived from the validated 1-6 shape, with local database reset and source-database dependencies removed.
+
+## Files
+
+- Inspection script: database/bash/prop_candidiate/cloud/cloud_step_015_inspect_local_script_for_azure.sh
+- Inspection output: database/targeting/prop_candidate/cloud/cloud_step_015_local_script_azure_inspection.txt

--- a/database/targeting/prop_candidate/cloud/cloud_step_015_local_script_azure_inspection.txt
+++ b/database/targeting/prop_candidate/cloud/cloud_step_015_local_script_azure_inspection.txt
@@ -1,0 +1,87 @@
+SOURCE=database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql
+SOURCE_SHA256=2937841E03F23255C9A5483BDC8BAECD93240A14D52F0CE76A9CAE7B307C2FBD
+SOURCE_LINES=766
+
+CHECK=Dead database reference COUNT=0
+
+CHECK=Local repeatbuild database reference COUNT=9
+11:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+13:    ALTER DATABASE [PluralBridge_RepeatBuild]
+16:    DROP DATABASE [PluralBridge_RepeatBuild];
+20:DBCC CLONEDATABASE (N'PluralBridge', N'PluralBridge_RepeatBuild');
+23:ALTER DATABASE [PluralBridge_RepeatBuild]
+27:ALTER DATABASE [PluralBridge_RepeatBuild]
+37:WHERE name = N'PluralBridge_RepeatBuild';
+40:USE [PluralBridge_RepeatBuild];
+747:USE [PluralBridge_RepeatBuild];
+
+CHECK=Prequel reference COUNT=25
+86:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+89:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+99:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+100:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+101:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+102:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+103:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+104:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+105:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+106:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+107:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+108:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+157:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+179:FROM [PluralBridge-Prequel].dbo.me AS me
+240:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+251:FROM [PluralBridge-Prequel].dbo.me AS me;
+288:FROM [PluralBridge-Prequel].dbo.members AS m
+350:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+360:FROM [PluralBridge-Prequel].dbo.me AS me;
+389:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+
+CHECK=Preop reference COUNT=0
+
+CHECK=USE statement COUNT=3
+8:USE [master];
+40:USE [PluralBridge_RepeatBuild];
+747:USE [PluralBridge_RepeatBuild];
+
+CHECK=CREATE DATABASE statement COUNT=0
+
+CHECK=DROP DATABASE statement COUNT=1
+16:    DROP DATABASE [PluralBridge_RepeatBuild];
+
+CHECK=ALTER DATABASE statement COUNT=3
+13:    ALTER DATABASE [PluralBridge_RepeatBuild]
+23:ALTER DATABASE [PluralBridge_RepeatBuild]
+27:ALTER DATABASE [PluralBridge_RepeatBuild]
+
+CHECK=File path or filegroup option COUNT=0
+
+CHECK=Single user multi user rollback option COUNT=2
+14:        SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+28:    SET MULTI_USER;
+
+CHECK=SQLCMD directive COUNT=0
+
+CHECK=SQLCMD variable token COUNT=0
+
+CHECK=Bulk external file operation COUNT=0
+
+CHECK=Private JSON path leak COUNT=0
+
+CHECK=GO batch separator COUNT=15
+9:GO
+18:GO
+21:GO
+25:GO
+29:GO
+38:GO
+41:GO
+47:GO
+146:GO
+230:GO
+339:GO
+440:GO
+542:GO
+740:GO
+748:GO
+

--- a/database/targeting/prop_candidate/cloud/cloud_step_016_azure_execution_boundaries.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_016_azure_execution_boundaries.md
@@ -1,0 +1,51 @@
+# Cloud Step 16 Azure SQL Execution Boundaries
+
+Date: 2026-06-06 PT
+
+## Branch context
+
+- Logical branch #1 has been merged to dev.
+- Logical branch #2 is feature/002-cloud-readiness.
+- Logical branch #2 has been rebased onto dev after the logical branch #1 merge.
+- Current cloud branch checkpoint before Azure SQL candidate generation: a5a6dc1.
+
+## Azure SQL execution boundary
+
+The first Azure proof will use a target-database script, not a local repeat-build script.
+
+The Azure candidate script must assume SSMS is already connected to the intended Azure SQL target database.
+
+The Azure candidate script must not include:
+
+- USE statements
+- CREATE DATABASE statements
+- DROP DATABASE statements
+- ALTER DATABASE statements
+- DBCC CLONEDATABASE statements
+- SINGLE_USER, MULTI_USER, or ROLLBACK IMMEDIATE reset logic
+- References to PluralBridge_RepeatBuild
+- References to PluralBridge_RebuildScratch
+- References to PluralBridge-Prequel as a live source database
+- References to PluralBridge_Preop
+- sqlcmd directives or sqlcmd variable tokens
+- Private JSON payload paths or committed JSON payload data
+
+## Target database naming
+
+Recommended first Azure SQL proof database name: PluralBridgeCloudProof001.
+
+The Azure SQL database may be created outside this repository workflow through the Azure portal or another explicit Azure administration path. Repository scripts for this phase begin after the empty target database exists and SSMS is connected to it.
+
+## First cloud proof model
+
+The first cloud proof should use seeded 1-6 SQL derived from the validated local repeat-build shape.
+
+JSON import from ignored private files is deferred until the Azure SQL schema and seeded 1-6 proof are validated.
+
+## Execution rule
+
+Azure SQL DDL and DML execution happens only in SSMS. Git Bash may generate files and run text audits only.
+
+## Next step
+
+Generate an Azure SQL candidate script derived from the validated local 1-6 repeat-build shape, with local reset logic and live source-database dependencies removed.

--- a/database/targeting/prop_candidate/cloud/cloud_step_017b_azure_portal_setup_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_017b_azure_portal_setup_audit.md
@@ -1,0 +1,51 @@
+# Cloud Step 17B Azure Portal Setup Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD entering Azure setup: 8a38e90
+- Remote branch before later push: origin/feature/002-cloud-readiness at a5a6dc1
+- Repository/SSMS work paused because no Azure SQL target database existed yet.
+
+## Azure resources
+
+- Subscription shown: Azure subscription 1
+- Resource group: rg-pluralbridge-cloudproof
+- Database: PluralBridgeCloudProof001
+- Logical server: pluralbridge-cloudproof-syf001
+- Server endpoint: pluralbridge-cloudproof-syf001.database.windows.net
+- Region: West US 2
+- East US rejected by subscription; West US 2 accepted.
+
+## Configuration summary
+
+- Authentication: SQL authentication
+- Admin login: pbadmin
+- Password: excluded from repository and audit text
+- Workload: Development
+- Elastic pool: No
+- Compute: General Purpose, Serverless, Standard-series Gen5, 1 max vCore, 0.5 min vCore
+- Auto-pause: enabled, 1 hour
+- Data max size: 32 GB
+- Zone redundant: No
+- Backup redundancy: Locally-redundant backup storage
+- Data source: Blank
+- Collation: SQL_Latin1_General_CP1_CI_AS
+
+## Networking and security
+
+- Connectivity: Public endpoint
+- Allow Azure services: No
+- Client IP added in create flow: 169.197.57.232
+- Minimum TLS: 1.2
+- Microsoft Defender for SQL: Not now
+- TDE: service-managed key
+- Always Encrypted secure enclaves: Off
+
+## Result and next action
+
+- Azure portal reported deployment succeeded.
+- Database overview page loaded for PluralBridgeCloudProof001.
+- Next: verify server firewall rule, then connect SSMS to PluralBridgeCloudProof001.

--- a/database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql
+++ b/database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql
@@ -1,0 +1,49 @@
+-- Cloud Step 18 start
+-- Azure SQL read-only connection smoke test.
+-- Run in SSMS against PluralBridgeCloudProof001 on pluralbridge-cloudproof-syf001.database.windows.net.
+
+SET NOCOUNT ON;
+
+SELECT
+    DB_NAME() AS CurrentDatabase,
+    SUSER_SNAME() AS LoginName,
+    SERVERPROPERTY('ServerName') AS ServerName,
+    SERVERPROPERTY('EngineEdition') AS EngineEdition,
+    SERVERPROPERTY('Edition') AS Edition,
+    SERVERPROPERTY('ProductVersion') AS ProductVersion,
+    SYSUTCDATETIME() AS CheckedAtUtc;
+
+SELECT
+    name,
+    compatibility_level,
+    collation_name,
+    state_desc,
+    containment_desc,
+    create_date
+FROM sys.databases
+WHERE name = DB_NAME();
+
+SELECT
+    s.name AS SchemaName
+FROM sys.schemas AS s
+WHERE s.name = N'dbo'
+ORDER BY s.name;
+
+SELECT
+    t.name AS ExistingPluralBridgeTable
+FROM sys.tables AS t
+WHERE t.name IN
+(
+    N'pb_source_systems',
+    N'pb_import_batches',
+    N'pb_systems',
+    N'pb_members',
+    N'pb_privacy_buckets',
+    N'pb_custom_fields',
+    N'pb_front_history',
+    N'pb_source_records',
+    N'pb_source_id_map'
+)
+ORDER BY t.name;
+
+-- Cloud Step 18 end

--- a/database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test_audit.md
@@ -1,0 +1,38 @@
+# Cloud Step 18 Azure Connection Smoke Test Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD: 8a38e90
+- SQL file: database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql
+- Execution surface: SSMS against Azure SQL
+
+## Azure SQL target
+
+- Server endpoint: pluralbridge-cloudproof-syf001.database.windows.net
+- ServerName result: pluralbridge-cloudproof-syf001
+- Database: PluralBridgeCloudProof001
+- LoginName result: pbadmin
+- EngineEdition result: 5
+- Edition result: SQL Azure
+- ProductVersion result: 12.0.2000.8
+
+## Database verification
+
+- CurrentDatabase result: PluralBridgeCloudProof001
+- Compatibility level: 170
+- Collation: SQL_Latin1_General_CP1_CI_AS
+- State: ONLINE
+- Containment: NONE
+- dbo schema present: yes
+- Existing PluralBridge pb_* tables: none
+
+## Result
+
+Cloud Step 18 passed. SSMS can connect to the empty Azure SQL proof database, and the target database contains no existing PluralBridge pb_* tables.
+
+## Next action
+
+Generate or identify the Azure-compatible schema source for the pb_* 1-6 proof tables before any DDL/DML execution.

--- a/database/targeting/prop_candidate/cloud/cloud_step_019a_schema_source_inventory.txt
+++ b/database/targeting/prop_candidate/cloud/cloud_step_019a_schema_source_inventory.txt
@@ -1,0 +1,2012 @@
+CLOUD STEP 19A SCHEMA SOURCE INVENTORY
+BRANCH=feature/002-cloud-readiness
+HEAD=1fba552
+
+CREATE/ALTER TABLE HITS
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:4:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:14:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:29:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:45:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:67:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:82:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:97:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:114:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:128:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:142:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:143:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:144:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:145:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:146:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:147:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:148:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:149:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:150:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:151:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:14:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:24:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:39:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:55:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:77:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:92:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:107:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:124:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:138:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:152:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:153:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:154:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:155:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:156:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:157:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:158:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:159:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:160:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:161:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:4:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:14:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:29:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:45:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:67:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:82:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:97:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:114:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:128:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:142:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:143:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:144:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:145:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:146:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:147:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:148:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:149:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:150:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:151:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:6:    CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:19:    CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:37:    CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:56:    CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:81:    CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:99:    CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:117:    CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:137:    CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:154:    CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:171:    ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:176:    ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:181:    ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:186:    ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:191:    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:196:    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:201:    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:206:    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:211:    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:216:    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+
+PB TARGET TABLE HITS
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:37:    N'pb_source_systems',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:38:    N'pb_import_batches',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:39:    N'pb_systems',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:40:    N'pb_members',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:41:    N'pb_privacy_buckets',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:42:    N'pb_custom_fields',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:43:    N'pb_front_history',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:44:    N'pb_source_records',
+database/targeting/prop_candidate/cloud/cloud_step_018_azure_connection_smoke_test.sql:45:    N'pb_source_id_map'
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:55:    FROM dbo.pb_source_systems
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:59:    INSERT INTO dbo.pb_source_systems (
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:74:FROM dbo.pb_source_systems
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:113:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:115:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:118:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:140:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:142:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:182:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:192:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:198:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:205:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:207:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:217:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:224:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:225:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:226:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:256:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:261:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:291:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:301:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:307:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:314:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:316:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:326:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:333:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:334:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:335:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:364:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:369:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:392:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:402:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:408:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:415:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:417:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:427:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:434:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:435:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:436:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:466:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:471:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:494:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:504:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:510:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:517:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:519:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:529:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:536:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:537:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:538:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:558:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:609:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:613:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:621:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:653:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:657:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:683:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:689:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:695:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:719:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:725:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:731:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:732:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:733:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:753:    SELECT 'pb_import_batches' AS CheckName, CAST(1 AS bigint) AS ExpectedCount, COUNT_BIG(*) AS ActualCount FROM dbo.pb_import_batches
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:754:    UNION ALL SELECT 'pb_systems', CAST(1 AS bigint), COUNT_BIG(*) FROM dbo.pb_systems
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:755:    UNION ALL SELECT 'pb_members', CAST(49 AS bigint), COUNT_BIG(*) FROM dbo.pb_members
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:756:    UNION ALL SELECT 'pb_privacy_buckets', CAST(2 AS bigint), COUNT_BIG(*) FROM dbo.pb_privacy_buckets
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:757:    UNION ALL SELECT 'pb_custom_fields', CAST(7 AS bigint), COUNT_BIG(*) FROM dbo.pb_custom_fields
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:758:    UNION ALL SELECT 'pb_front_history', CAST(886 AS bigint), COUNT_BIG(*) FROM dbo.pb_front_history
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:759:    UNION ALL SELECT 'pb_source_records 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:760:    UNION ALL SELECT 'pb_source_id_map 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:8:    SELECT 'pb_import_batches' AS CheckName, CAST(1 AS bigint) AS ExpectedCount, COUNT_BIG(*) AS ActualCount FROM dbo.pb_import_batches
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:9:    UNION ALL SELECT 'pb_systems', CAST(1 AS bigint), COUNT_BIG(*) FROM dbo.pb_systems
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:10:    UNION ALL SELECT 'pb_members', CAST(49 AS bigint), COUNT_BIG(*) FROM dbo.pb_members
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:11:    UNION ALL SELECT 'pb_privacy_buckets', CAST(2 AS bigint), COUNT_BIG(*) FROM dbo.pb_privacy_buckets
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:12:    UNION ALL SELECT 'pb_custom_fields', CAST(7 AS bigint), COUNT_BIG(*) FROM dbo.pb_custom_fields
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:13:    UNION ALL SELECT 'pb_front_history', CAST(886 AS bigint), COUNT_BIG(*) FROM dbo.pb_front_history
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:14:    UNION ALL SELECT 'pb_source_records 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:15:    UNION ALL SELECT 'pb_source_id_map 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_007_seed_source_systems_literal.sql:4:    FROM dbo.pb_source_systems
+database/targeting/prop_candidate/pop_candidate_step_007_seed_source_systems_literal.sql:8:    INSERT INTO dbo.pb_source_systems (
+database/targeting/prop_candidate/pop_candidate_step_007_seed_source_systems_literal.sql:23:FROM dbo.pb_source_systems
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:35:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:37:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:40:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:62:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:64:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:104:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:114:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:120:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:127:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:129:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:139:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:146:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:147:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:148:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:178:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:183:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:213:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:223:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:229:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:236:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:238:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:248:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:255:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:256:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:257:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:286:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:291:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:314:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:324:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:330:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:337:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:339:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:349:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:356:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:357:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:358:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:388:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:393:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:416:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:426:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:432:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:439:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:441:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:451:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:458:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:459:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:460:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:480:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:531:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:535:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:543:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:575:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:579:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:605:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:611:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:617:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:641:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:647:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:653:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:654:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:655:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:7:SELECT ExportName = N'pb_source_systems', JsonData = (SELECT * FROM dbo.pb_source_systems ORDER BY SourceSystemCode FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:8:SELECT ExportName = N'pb_import_batches', JsonData = (SELECT * FROM dbo.pb_import_batches ORDER BY ImportBatchId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:9:SELECT ExportName = N'pb_systems', JsonData = (SELECT * FROM dbo.pb_systems ORDER BY SystemId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:10:SELECT ExportName = N'pb_members', JsonData = (SELECT * FROM dbo.pb_members ORDER BY MemberId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:11:SELECT ExportName = N'pb_privacy_buckets', JsonData = (SELECT * FROM dbo.pb_privacy_buckets ORDER BY PrivacyBucketId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:12:SELECT ExportName = N'pb_custom_fields', JsonData = (SELECT * FROM dbo.pb_custom_fields ORDER BY CustomFieldId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:13:SELECT ExportName = N'pb_front_history', JsonData = (SELECT * FROM dbo.pb_front_history ORDER BY StartTimeMs, FrontHistoryId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:14:SELECT ExportName = N'pb_source_records', JsonData = (SELECT * FROM dbo.pb_source_records ORDER BY SourceSystemCode, SourceEntityTypeCode, SourceId, SourceRecordId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:15:SELECT ExportName = N'pb_source_id_map', JsonData = (SELECT * FROM dbo.pb_source_id_map ORDER BY SourceSystemCode, SourceEntityTypeCode, SourceId, SourceIdMapId FOR JSON PATH, INCLUDE_NULL_VALUES);
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:17:SELECT CheckName = N'pb_import_batches', ActualCount = COUNT(*) FROM dbo.pb_import_batches;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:18:SELECT CheckName = N'pb_systems', ActualCount = COUNT(*) FROM dbo.pb_systems;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:19:SELECT CheckName = N'pb_members', ActualCount = COUNT(*) FROM dbo.pb_members;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:20:SELECT CheckName = N'pb_privacy_buckets', ActualCount = COUNT(*) FROM dbo.pb_privacy_buckets;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:21:SELECT CheckName = N'pb_custom_fields', ActualCount = COUNT(*) FROM dbo.pb_custom_fields;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:22:SELECT CheckName = N'pb_front_history', ActualCount = COUNT(*) FROM dbo.pb_front_history;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:23:SELECT CheckName = N'pb_source_records', ActualCount = COUNT(*) FROM dbo.pb_source_records;
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:24:SELECT CheckName = N'pb_source_id_map', ActualCount = COUNT(*) FROM dbo.pb_source_id_map;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:4:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:10:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:11:    CONSTRAINT PK_pb_source_systems PRIMARY KEY CLUSTERED (SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:14:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:16:    ImportBatchId uniqueidentifier NOT NULL CONSTRAINT DF_pb_import_batches_ImportBatchId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:25:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_import_batches_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:26:    CONSTRAINT PK_pb_import_batches PRIMARY KEY CLUSTERED (ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:29:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:31:    SystemId uniqueidentifier NOT NULL CONSTRAINT DF_pb_systems_SystemId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:39:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:40:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:42:    CONSTRAINT PK_pb_systems PRIMARY KEY CLUSTERED (SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:45:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:47:    MemberId uniqueidentifier NOT NULL CONSTRAINT DF_pb_members_MemberId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:61:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:62:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:64:    CONSTRAINT PK_pb_members PRIMARY KEY CLUSTERED (MemberId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:67:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:69:    PrivacyBucketId uniqueidentifier NOT NULL CONSTRAINT DF_pb_privacy_buckets_PrivacyBucketId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:76:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:77:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:79:    CONSTRAINT PK_pb_privacy_buckets PRIMARY KEY CLUSTERED (PrivacyBucketId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:82:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:84:    CustomFieldId uniqueidentifier NOT NULL CONSTRAINT DF_pb_custom_fields_CustomFieldId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:91:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:92:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:94:    CONSTRAINT PK_pb_custom_fields PRIMARY KEY CLUSTERED (CustomFieldId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:97:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:99:    FrontHistoryId uniqueidentifier NOT NULL CONSTRAINT DF_pb_front_history_FrontHistoryId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:108:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:109:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:111:    CONSTRAINT PK_pb_front_history PRIMARY KEY CLUSTERED (FrontHistoryId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:114:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:116:    SourceRecordId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_records_SourceRecordId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:124:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_records_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:125:    CONSTRAINT PK_pb_source_records PRIMARY KEY CLUSTERED (SourceRecordId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:128:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:130:    SourceIdMapId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_id_map_SourceIdMapId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:137:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_id_map_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:138:    CONSTRAINT PK_pb_source_id_map PRIMARY KEY CLUSTERED (SourceIdMapId),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:139:    CONSTRAINT UQ_pb_source_id_map_SourceIdentity UNIQUE NONCLUSTERED (SourceSystemCode, SourceEntityTypeCode, SourceId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:142:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:143:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:144:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:145:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:146:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:147:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:148:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:149:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:150:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_reset_step_002_create_correct_001_006_schema.sql:151:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:38:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:40:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:43:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:65:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:67:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:107:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:117:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:123:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:130:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:132:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:142:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:149:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:150:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:151:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:181:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:186:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:216:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:226:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:232:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:239:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:241:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:251:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:258:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:259:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:260:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:289:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:294:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:317:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:327:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:333:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:340:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:342:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:352:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:359:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:360:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:361:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:391:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:396:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:419:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:429:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:435:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:442:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:444:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:454:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:461:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:462:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:463:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:525:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:529:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:537:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:569:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:573:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:599:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:605:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:611:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:635:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:641:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:647:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:648:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:649:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:19:    'pb_import_batches',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:20:    'pb_source_systems',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:21:    'pb_source_records',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:22:    'pb_source_id_map',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:23:    'pb_systems',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:24:    'pb_members',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:25:    'pb_privacy_buckets',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:26:    'pb_custom_fields',
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_004_inspect_001_006_required_table_columns.sql:27:    'pb_front_history'
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_005_inspect_001_006_required_keys.sql:14:WHERE t.name IN ('pb_import_batches','pb_source_systems','pb_source_records','pb_source_id_map','pb_systems','pb_members','pb_privacy_buckets','pb_custom_fields','pb_front_history')
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_005_inspect_001_006_required_keys.sql:30:WHERE tp.name IN ('pb_import_batches','pb_source_systems','pb_source_records','pb_source_id_map','pb_systems','pb_members','pb_privacy_buckets','pb_custom_fields','pb_front_history')
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_inspect_apparyllis_source_system_seed.sql:9:FROM dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:8:    SELECT 'pb_import_batches' AS CheckName, CAST(1 AS bigint) AS ExpectedCount, COUNT_BIG(*) AS ActualCount FROM dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:9:    UNION ALL SELECT 'pb_systems', CAST(1 AS bigint), COUNT_BIG(*) FROM dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:10:    UNION ALL SELECT 'pb_members', CAST(49 AS bigint), COUNT_BIG(*) FROM dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:11:    UNION ALL SELECT 'pb_privacy_buckets', CAST(2 AS bigint), COUNT_BIG(*) FROM dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:12:    UNION ALL SELECT 'pb_custom_fields', CAST(7 AS bigint), COUNT_BIG(*) FROM dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:13:    UNION ALL SELECT 'pb_front_history', CAST(886 AS bigint), COUNT_BIG(*) FROM dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:14:    UNION ALL SELECT 'pb_source_records 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:15:    UNION ALL SELECT 'pb_source_id_map 1-6 total', CAST(945 AS bigint), COUNT_BIG(*) FROM dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_007_seed_source_systems_literal.sql:4:    FROM dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_007_seed_source_systems_literal.sql:8:    INSERT INTO dbo.pb_source_systems (
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_007_seed_source_systems_literal.sql:23:FROM dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:38:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:40:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:43:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:65:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:67:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:107:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:117:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:123:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:130:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:132:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:142:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:149:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:150:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:151:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:181:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:186:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:216:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:226:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:232:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:239:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:241:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:251:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:258:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:259:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:260:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:289:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:294:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:317:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:327:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:333:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:340:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:342:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:352:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:359:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:360:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:361:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:391:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:396:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:419:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:429:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:435:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:442:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:444:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:454:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:461:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:462:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:463:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:525:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:529:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:537:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:569:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:573:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:599:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:605:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:611:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:635:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:641:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:647:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:648:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:649:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_011_seed_source_systems_from_baseline.sql:5:INSERT INTO dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_011_seed_source_systems_from_baseline.sql:7:FROM PluralBridge.dbo.pb_source_systems AS src
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_011_seed_source_systems_from_baseline.sql:10:    FROM dbo.pb_source_systems AS dst
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_011_seed_source_systems_from_baseline.sql:15:FROM dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:35:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:37:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:40:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:62:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:64:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:104:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:114:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:120:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:127:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:129:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:139:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:146:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:147:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:148:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:178:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:183:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:213:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:223:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:229:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:236:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:238:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:248:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:255:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:256:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:257:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:286:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:291:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:314:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:324:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:330:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:337:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:339:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:349:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:356:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:357:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:358:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:388:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:393:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:416:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:426:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:432:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:439:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:441:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:451:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:458:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:459:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:460:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:480:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:531:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:535:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:543:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:575:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:579:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:605:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:611:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:617:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:641:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:647:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:653:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:654:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:655:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:38:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:40:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:43:INSERT INTO dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:65:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:67:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:107:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:117:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:123:INSERT INTO dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:130:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:132:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:142:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:149:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:150:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:151:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:181:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:186:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:216:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:226:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:232:INSERT INTO dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:239:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:241:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:251:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:258:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:259:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:260:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:289:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:294:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:317:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:327:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:333:INSERT INTO dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:340:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:342:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:352:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:359:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:360:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:361:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:391:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:396:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:419:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:429:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:435:INSERT INTO dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:442:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:444:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:454:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:461:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:462:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:463:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:480:    FROM dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:530:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:534:INNER JOIN dbo.pb_source_id_map AS membermap
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:542:INSERT INTO dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:574:    FROM dbo.pb_front_history AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:578:INSERT INTO dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:604:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:610:    FROM dbo.pb_source_records AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:616:INSERT INTO dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:640:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:646:    FROM dbo.pb_source_id_map AS existing
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:652:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:653:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:654:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:4:DROP TABLE IF EXISTS dbo.pb_source_id_map;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:5:DROP TABLE IF EXISTS dbo.pb_source_records;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:6:DROP TABLE IF EXISTS dbo.pb_front_history;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:7:DROP TABLE IF EXISTS dbo.pb_custom_fields;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:8:DROP TABLE IF EXISTS dbo.pb_privacy_buckets;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:9:DROP TABLE IF EXISTS dbo.pb_members;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:10:DROP TABLE IF EXISTS dbo.pb_systems;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:11:DROP TABLE IF EXISTS dbo.pb_import_batches;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:12:DROP TABLE IF EXISTS dbo.pb_source_systems;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:14:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:20:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:21:    CONSTRAINT PK_pb_source_systems PRIMARY KEY CLUSTERED (SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:24:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:26:    ImportBatchId uniqueidentifier NOT NULL CONSTRAINT DF_pb_import_batches_ImportBatchId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:35:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_import_batches_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:36:    CONSTRAINT PK_pb_import_batches PRIMARY KEY CLUSTERED (ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:39:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:41:    SystemId uniqueidentifier NOT NULL CONSTRAINT DF_pb_systems_SystemId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:49:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:50:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:52:    CONSTRAINT PK_pb_systems PRIMARY KEY CLUSTERED (SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:55:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:57:    MemberId uniqueidentifier NOT NULL CONSTRAINT DF_pb_members_MemberId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:71:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:72:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:74:    CONSTRAINT PK_pb_members PRIMARY KEY CLUSTERED (MemberId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:77:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:79:    PrivacyBucketId uniqueidentifier NOT NULL CONSTRAINT DF_pb_privacy_buckets_PrivacyBucketId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:86:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:87:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:89:    CONSTRAINT PK_pb_privacy_buckets PRIMARY KEY CLUSTERED (PrivacyBucketId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:92:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:94:    CustomFieldId uniqueidentifier NOT NULL CONSTRAINT DF_pb_custom_fields_CustomFieldId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:101:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:102:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:104:    CONSTRAINT PK_pb_custom_fields PRIMARY KEY CLUSTERED (CustomFieldId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:107:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:109:    FrontHistoryId uniqueidentifier NOT NULL CONSTRAINT DF_pb_front_history_FrontHistoryId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:118:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:119:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:121:    CONSTRAINT PK_pb_front_history PRIMARY KEY CLUSTERED (FrontHistoryId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:124:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:126:    SourceRecordId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_records_SourceRecordId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:134:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_records_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:135:    CONSTRAINT PK_pb_source_records PRIMARY KEY CLUSTERED (SourceRecordId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:138:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:140:    SourceIdMapId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_id_map_SourceIdMapId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:147:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_id_map_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:148:    CONSTRAINT PK_pb_source_id_map PRIMARY KEY CLUSTERED (SourceIdMapId),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:149:    CONSTRAINT UQ_pb_source_id_map_SourceIdentity UNIQUE NONCLUSTERED (SourceSystemCode, SourceEntityTypeCode, SourceId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:152:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:153:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:154:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:155:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:156:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:157:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:158:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:159:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:160:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_018_create_001_006_schema.sql:161:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:4:CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:10:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:11:    CONSTRAINT PK_pb_source_systems PRIMARY KEY CLUSTERED (SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:14:CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:16:    ImportBatchId uniqueidentifier NOT NULL CONSTRAINT DF_pb_import_batches_ImportBatchId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:25:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_import_batches_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:26:    CONSTRAINT PK_pb_import_batches PRIMARY KEY CLUSTERED (ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:29:CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:31:    SystemId uniqueidentifier NOT NULL CONSTRAINT DF_pb_systems_SystemId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:39:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:40:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:42:    CONSTRAINT PK_pb_systems PRIMARY KEY CLUSTERED (SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:45:CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:47:    MemberId uniqueidentifier NOT NULL CONSTRAINT DF_pb_members_MemberId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:61:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:62:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:64:    CONSTRAINT PK_pb_members PRIMARY KEY CLUSTERED (MemberId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:67:CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:69:    PrivacyBucketId uniqueidentifier NOT NULL CONSTRAINT DF_pb_privacy_buckets_PrivacyBucketId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:76:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:77:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:79:    CONSTRAINT PK_pb_privacy_buckets PRIMARY KEY CLUSTERED (PrivacyBucketId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:82:CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:84:    CustomFieldId uniqueidentifier NOT NULL CONSTRAINT DF_pb_custom_fields_CustomFieldId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:91:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:92:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:94:    CONSTRAINT PK_pb_custom_fields PRIMARY KEY CLUSTERED (CustomFieldId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:97:CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:99:    FrontHistoryId uniqueidentifier NOT NULL CONSTRAINT DF_pb_front_history_FrontHistoryId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:108:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:109:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:111:    CONSTRAINT PK_pb_front_history PRIMARY KEY CLUSTERED (FrontHistoryId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:114:CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:116:    SourceRecordId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_records_SourceRecordId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:124:    ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_records_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:125:    CONSTRAINT PK_pb_source_records PRIMARY KEY CLUSTERED (SourceRecordId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:128:CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:130:    SourceIdMapId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_id_map_SourceIdMapId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:137:    CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_id_map_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:138:    CONSTRAINT PK_pb_source_id_map PRIMARY KEY CLUSTERED (SourceIdMapId),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:139:    CONSTRAINT UQ_pb_source_id_map_SourceIdentity UNIQUE NONCLUSTERED (SourceSystemCode, SourceEntityTypeCode, SourceId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:142:ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:143:ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:144:ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:145:ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:146:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:147:ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:148:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:149:ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:150:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_020_create_001_006_schema_create_only.sql:151:ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:4:IF OBJECT_ID(N'dbo.pb_source_systems', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:6:    CREATE TABLE dbo.pb_source_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:12:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:13:        CONSTRAINT PK_pb_source_systems PRIMARY KEY CLUSTERED (SourceSystemCode)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:17:IF OBJECT_ID(N'dbo.pb_import_batches', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:19:    CREATE TABLE dbo.pb_import_batches
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:21:        ImportBatchId uniqueidentifier NOT NULL CONSTRAINT DF_pb_import_batches_ImportBatchId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:30:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_import_batches_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:31:        CONSTRAINT PK_pb_import_batches PRIMARY KEY CLUSTERED (ImportBatchId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:35:IF OBJECT_ID(N'dbo.pb_systems', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:37:    CREATE TABLE dbo.pb_systems
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:39:        SystemId uniqueidentifier NOT NULL CONSTRAINT DF_pb_systems_SystemId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:47:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:48:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:50:        CONSTRAINT PK_pb_systems PRIMARY KEY CLUSTERED (SystemId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:54:IF OBJECT_ID(N'dbo.pb_members', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:56:    CREATE TABLE dbo.pb_members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:58:        MemberId uniqueidentifier NOT NULL CONSTRAINT DF_pb_members_MemberId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:72:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:73:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:75:        CONSTRAINT PK_pb_members PRIMARY KEY CLUSTERED (MemberId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:79:IF OBJECT_ID(N'dbo.pb_privacy_buckets', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:81:    CREATE TABLE dbo.pb_privacy_buckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:83:        PrivacyBucketId uniqueidentifier NOT NULL CONSTRAINT DF_pb_privacy_buckets_PrivacyBucketId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:90:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:91:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:93:        CONSTRAINT PK_pb_privacy_buckets PRIMARY KEY CLUSTERED (PrivacyBucketId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:97:IF OBJECT_ID(N'dbo.pb_custom_fields', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:99:    CREATE TABLE dbo.pb_custom_fields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:101:        CustomFieldId uniqueidentifier NOT NULL CONSTRAINT DF_pb_custom_fields_CustomFieldId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:108:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:109:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:111:        CONSTRAINT PK_pb_custom_fields PRIMARY KEY CLUSTERED (CustomFieldId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:115:IF OBJECT_ID(N'dbo.pb_front_history', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:117:    CREATE TABLE dbo.pb_front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:119:        FrontHistoryId uniqueidentifier NOT NULL CONSTRAINT DF_pb_front_history_FrontHistoryId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:128:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:129:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:131:        CONSTRAINT PK_pb_front_history PRIMARY KEY CLUSTERED (FrontHistoryId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:135:IF OBJECT_ID(N'dbo.pb_source_records', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:137:    CREATE TABLE dbo.pb_source_records
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:139:        SourceRecordId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_records_SourceRecordId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:147:        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_records_ImportedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:148:        CONSTRAINT PK_pb_source_records PRIMARY KEY CLUSTERED (SourceRecordId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:152:IF OBJECT_ID(N'dbo.pb_source_id_map', N'U') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:154:    CREATE TABLE dbo.pb_source_id_map
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:156:        SourceIdMapId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_id_map_SourceIdMapId DEFAULT (newsequentialid()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:163:        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_id_map_CreatedAtUtc DEFAULT (sysutcdatetime()),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:164:        CONSTRAINT PK_pb_source_id_map PRIMARY KEY CLUSTERED (SourceIdMapId),
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:165:        CONSTRAINT UQ_pb_source_id_map_SourceIdentity UNIQUE NONCLUSTERED (SourceSystemCode, SourceEntityTypeCode, SourceId)
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:169:IF OBJECT_ID(N'dbo.FK_pb_import_batches_pb_source_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:171:    ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:174:IF OBJECT_ID(N'dbo.FK_pb_members_pb_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:176:    ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:179:IF OBJECT_ID(N'dbo.FK_pb_privacy_buckets_pb_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:181:    ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:184:IF OBJECT_ID(N'dbo.FK_pb_custom_fields_pb_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:186:    ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:189:IF OBJECT_ID(N'dbo.FK_pb_front_history_pb_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:191:    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:194:IF OBJECT_ID(N'dbo.FK_pb_front_history_pb_members', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:196:    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:199:IF OBJECT_ID(N'dbo.FK_pb_source_records_pb_import_batches', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:201:    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:204:IF OBJECT_ID(N'dbo.FK_pb_source_records_pb_source_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:206:    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:209:IF OBJECT_ID(N'dbo.FK_pb_source_id_map_pb_import_batches', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:211:    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:214:IF OBJECT_ID(N'dbo.FK_pb_source_id_map_pb_source_systems', N'F') IS NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql:216:    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:37:    Npb_source_systems,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:38:    Npb_import_batches,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:39:    Npb_systems,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:40:    Npb_members,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:41:    Npb_privacy_buckets,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:42:    Npb_custom_fields,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:43:    Npb_front_history,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:44:    Npb_source_records,
+database/targeting/prop_candidate_fail_20260606_cloud_smoke_sql_quote_error/cloud_step_017_azure_target_connection_smoke_test.sql:45:    Npb_source_id_map
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:11:SELECT ScriptLine = CONCAT(N'-- pb_import_batches=', (SELECT COUNT(*) FROM dbo.pb_import_batches));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:12:SELECT ScriptLine = CONCAT(N'-- pb_systems=', (SELECT COUNT(*) FROM dbo.pb_systems));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:13:SELECT ScriptLine = CONCAT(N'-- pb_members=', (SELECT COUNT(*) FROM dbo.pb_members));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:14:SELECT ScriptLine = CONCAT(N'-- pb_privacy_buckets=', (SELECT COUNT(*) FROM dbo.pb_privacy_buckets));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:15:SELECT ScriptLine = CONCAT(N'-- pb_custom_fields=', (SELECT COUNT(*) FROM dbo.pb_custom_fields));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:16:SELECT ScriptLine = CONCAT(N'-- pb_front_history=', (SELECT COUNT(*) FROM dbo.pb_front_history));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:17:SELECT ScriptLine = CONCAT(N'-- pb_source_records 1-6 total=', (SELECT COUNT(*) FROM dbo.pb_source_records));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:18:SELECT ScriptLine = CONCAT(N'-- pb_source_id_map 1-6 total=', (SELECT COUNT(*) FROM dbo.pb_source_id_map));
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_003_generate_private_parent_inserts.sql:10:SELECT ScriptLine = CONCAT(N'INSERT INTO dbo.pb_source_systems (SourceSystemCode, DisplayName, Description, ApiBaseUrl, CreatedAtUtc) VALUES (N'', REPLACE(SourceSystemCode, N'', N''''), N''', N', N''', REPLACE(DisplayName, N'', N''''), N''', N', ', COALESCE(N'N''' + REPLACE(Description, N''', N'''') + N'''', N'NULL'), N', ', COALESCE(N'N''' + REPLACE(ApiBaseUrl, N''', N'''') + N'''', N'NULL'), N', ', N'''', CONVERT(nvarchar(30), CreatedAtUtc, 126), N'''', N');') FROM dbo.pb_source_systems ORDER BY SourceSystemCode;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:38:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:40:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:43:INSERT INTO dbo.pb_import_batches
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:65:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:67:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:107:INSERT INTO dbo.pb_source_records
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:117:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:123:INSERT INTO dbo.pb_systems
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:130:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:132:INSERT INTO dbo.pb_source_id_map
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:142:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:149:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:150:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:151:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:181:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:186:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:216:INSERT INTO dbo.pb_source_records
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:226:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:232:INSERT INTO dbo.pb_members
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:239:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:241:INSERT INTO dbo.pb_source_id_map
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:251:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:258:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:259:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:260:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:289:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:294:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:317:INSERT INTO dbo.pb_source_records
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:327:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:333:INSERT INTO dbo.pb_privacy_buckets
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:340:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:342:INSERT INTO dbo.pb_source_id_map
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:352:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:359:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:360:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:361:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:391:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:396:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:419:INSERT INTO dbo.pb_source_records
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:429:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:435:INSERT INTO dbo.pb_custom_fields
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:442:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:444:INSERT INTO dbo.pb_source_id_map
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:454:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:461:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:462:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:463:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:525:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:529:INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:537:INSERT INTO dbo.pb_front_history
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:569:    FROM dbo.pb_front_history AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:573:INSERT INTO dbo.pb_source_records
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:599:    FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:605:    FROM dbo.pb_source_records AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:611:INSERT INTO dbo.pb_source_id_map
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:635:    FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:641:    FROM dbo.pb_source_id_map AS existing
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:647:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:648:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:649:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:33:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:35:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:38:INSERT INTO dbo.pb_import_batches
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:60:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:62:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:34:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:44:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:50:INSERT INTO dbo.pb_systems
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:57:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:59:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:69:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:76:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:77:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:78:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:24:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:29:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:59:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:69:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:75:INSERT INTO dbo.pb_members
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:82:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:84:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:94:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:101:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:102:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:103:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:23:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:28:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:51:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:61:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:67:INSERT INTO dbo.pb_privacy_buckets
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:74:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:76:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:86:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:93:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:94:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:95:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:24:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:29:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:52:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:62:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:68:INSERT INTO dbo.pb_custom_fields
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:75:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:77:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:87:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:94:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:95:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:96:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:14:Target table: dbo.pb_front_history
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:52:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:56:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:61:INSERT INTO dbo.pb_front_history
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:93:    FROM dbo.pb_front_history AS existing
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:107:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:133:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:145:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:169:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:173:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:174:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:175:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_046_inspect_member_frame_corrected_paths.sql:88:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_048_create_003_member_frame_segment.sql:37:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:84:LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:88:LEFT JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_051_create_003_member_privacy_bucket_segment.sql:33:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_051_create_003_member_privacy_bucket_segment.sql:37:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:97:LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:101:LEFT JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:97:LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:101:LEFT JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_055_create_003_member_custom_field_value_segment.sql:37:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_055_create_003_member_custom_field_value_segment.sql:41:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:108:LEFT JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:112:LEFT JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_058_create_003_custom_field_privacy_bucket_segment.sql:34:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_058_create_003_custom_field_privacy_bucket_segment.sql:38:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:84:    LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_060_inspect_avatar_timestamp_policy.sql:47:INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_062_create_003_member_avatar_asset_segment.sql:42:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:83:    LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_065_create_003_source_note_file_segment.sql:50:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_065_create_003_source_note_file_segment.sql:54:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:113:LEFT JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:117:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:159:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:165:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:16:  dbo.pb_source_records for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:17:  dbo.pb_source_id_map for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:65:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:69:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:136:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:162:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:181:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:205:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:210:SELECT 'NOTE source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:211:SELECT 'NOTE source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:104:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:118:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:124:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:17:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:18:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:54:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:87:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:113:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:117:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:141:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:146:SELECT 'CHAT_CATEGORY source_records expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:147:SELECT 'CHAT_CATEGORY source_id_map expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:105:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:119:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:125:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:17:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:18:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:58:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:91:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:117:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:121:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:145:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:150:SELECT 'CHAT_CHANNEL source_records expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:151:SELECT 'CHAT_CHANNEL source_id_map expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:92:LEFT JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:96:LEFT JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:116:LEFT JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:120:LEFT JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_077_create_003_chat_category_channel_segment.sql:46:    INNER JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_077_create_003_chat_category_channel_segment.sql:50:    INNER JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:134:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:148:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:154:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_079_inspect_external_viewer_target_baseline.sql:61:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_079_inspect_external_viewer_target_baseline.sql:101:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_079_inspect_external_viewer_target_baseline.sql:112:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:19:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:20:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:99:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:125:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:129:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:153:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:158:SELECT 'EXTERNAL_VIEWER source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:159:SELECT 'EXTERNAL_VIEWER source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:175:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:188:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:194:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:54:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:96:LEFT JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:100:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:112:LEFT JOIN dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:19:  dbo.pb_source_records for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:20:  dbo.pb_source_id_map for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:57:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:94:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:120:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:124:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:148:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:153:SELECT 'SYSTEM_PROFILE_FIELD source_records expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:154:SELECT 'SYSTEM_PROFILE_FIELD source_id_map expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:55:FROM dbo.pb_source_records
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:59:FROM dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:63:FROM dbo.pb_source_id_map AS map
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:77:LEFT JOIN dbo.pb_source_id_map AS map_key ON map_key.SourceSystemCode = N'APPARYLLIS' AND map_key.SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD' AND map_key.SourceId = ef.field_array_key COLLATE DATABASE_DEFAULT
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:78:LEFT JOIN dbo.pb_source_id_map AS map_pair ON map_pair.SourceSystemCode = N'APPARYLLIS' AND map_pair.SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD' AND map_pair.SourceId = ef.external_viewer_source_id + N'|' + ef.field_array_key COLLATE DATABASE_DEFAULT;
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:87:LEFT JOIN dbo.pb_source_id_map AS viewer_map ON viewer_map.SourceSystemCode = N'APPARYLLIS' AND viewer_map.SourceEntityTypeCode = N'EXTERNAL_VIEWER' AND viewer_map.SourceId = ef.external_viewer_source_id COLLATE DATABASE_DEFAULT
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:88:LEFT JOIN dbo.pb_source_id_map AS profile_map ON profile_map.SourceSystemCode = N'APPARYLLIS' AND profile_map.SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD' AND profile_map.SourceId IN (ef.field_array_key, ef.external_viewer_source_id + N'|' + ef.field_array_key)
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:19:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:20:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:57:    INNER JOIN dbo.pb_source_id_map AS viewer_map
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:94:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:120:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:124:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:148:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:153:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_records expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:154:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_id_map expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:42:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:44:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:47:INSERT INTO dbo.pb_import_batches
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:69:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:71:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:113:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:123:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:129:INSERT INTO dbo.pb_systems
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:136:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:138:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:148:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:155:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:156:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:157:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:189:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:194:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:224:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:234:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:240:INSERT INTO dbo.pb_members
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:247:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:249:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:259:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:266:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:267:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:268:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:299:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:304:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:327:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:337:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:343:INSERT INTO dbo.pb_privacy_buckets
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:350:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:352:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:362:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:369:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:370:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:371:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:403:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:408:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:431:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:441:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:447:INSERT INTO dbo.pb_custom_fields
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:454:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:456:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:466:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:473:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:474:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:475:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:497:Target table: dbo.pb_front_history
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:535:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:539:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:544:INSERT INTO dbo.pb_front_history
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:576:    FROM dbo.pb_front_history AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:590:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:616:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:628:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:652:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:656:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:657:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:658:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:701:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:791:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:795:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:872:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:876:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:956:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:960:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1042:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1155:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1159:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1236:  dbo.pb_source_records for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1237:  dbo.pb_source_id_map for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1285:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1289:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1356:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1382:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1401:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1425:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1430:SELECT 'NOTE source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1431:SELECT 'NOTE source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1456:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1457:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1493:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1526:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1552:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1556:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1580:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1585:SELECT 'CHAT_CATEGORY source_records expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1586:SELECT 'CHAT_CATEGORY source_id_map expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1611:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1612:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1652:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1685:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1711:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1715:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1739:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1744:SELECT 'CHAT_CHANNEL source_records expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1745:SELECT 'CHAT_CHANNEL source_id_map expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1799:    INNER JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1803:    INNER JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1866:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1867:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1946:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1972:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1976:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2000:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2005:SELECT 'EXTERNAL_VIEWER source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2006:SELECT 'EXTERNAL_VIEWER source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2047:  dbo.pb_source_records for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2048:  dbo.pb_source_id_map for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2085:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2122:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2148:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2152:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2176:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2181:SELECT 'SYSTEM_PROFILE_FIELD source_records expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2182:SELECT 'SYSTEM_PROFILE_FIELD source_id_map expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2209:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2210:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2247:    INNER JOIN dbo.pb_source_id_map AS viewer_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2284:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2310:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2314:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2338:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2343:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_records expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2344:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_id_map expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:41:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:43:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:46:INSERT INTO dbo.pb_import_batches
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:68:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:70:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:113:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:123:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:129:INSERT INTO dbo.pb_systems
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:136:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:138:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:148:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:155:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:156:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:157:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:190:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:195:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:225:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:235:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:241:INSERT INTO dbo.pb_members
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:248:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:250:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:260:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:267:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:268:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:269:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:301:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:306:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:329:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:339:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:345:INSERT INTO dbo.pb_privacy_buckets
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:352:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:354:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:364:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:371:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:372:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:373:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:406:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:411:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:434:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:444:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:450:INSERT INTO dbo.pb_custom_fields
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:457:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:459:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:469:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:476:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:477:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:478:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:501:Target table: dbo.pb_front_history
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:539:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:543:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:548:INSERT INTO dbo.pb_front_history
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:580:    FROM dbo.pb_front_history AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:594:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:620:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:632:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:656:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:660:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:661:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:662:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:706:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:797:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:801:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:879:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:883:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:964:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:968:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1051:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1165:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1169:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1247:  dbo.pb_source_records for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1248:  dbo.pb_source_id_map for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1296:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1300:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1367:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1393:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1412:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1436:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1441:SELECT 'NOTE source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1442:SELECT 'NOTE source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1468:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1469:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1505:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1538:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1564:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1568:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1592:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1597:SELECT 'CHAT_CATEGORY source_records expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1598:SELECT 'CHAT_CATEGORY source_id_map expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1624:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1625:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1665:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1698:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1724:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1728:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1752:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1757:SELECT 'CHAT_CHANNEL source_records expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1758:SELECT 'CHAT_CHANNEL source_id_map expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1813:    INNER JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1817:    INNER JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1881:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1882:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1961:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1987:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1991:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2015:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2020:SELECT 'EXTERNAL_VIEWER source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2021:SELECT 'EXTERNAL_VIEWER source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2063:  dbo.pb_source_records for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2064:  dbo.pb_source_id_map for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2101:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2138:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2164:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2168:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2192:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2197:SELECT 'SYSTEM_PROFILE_FIELD source_records expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2198:SELECT 'SYSTEM_PROFILE_FIELD source_id_map expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2226:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2227:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2264:    INNER JOIN dbo.pb_source_id_map AS viewer_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2301:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2327:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2331:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2355:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2360:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_records expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2361:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_id_map expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:41:IF NOT EXISTS (SELECT 1 FROM dbo.pb_source_systems WHERE SourceSystemCode = @SourceSystemCode)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:43:    THROW 51000, 'Required source system APPARYLLIS is missing from dbo.pb_source_systems. Run 002_seed_lookup_data.sql first.', 1;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:46:INSERT INTO dbo.pb_import_batches
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:68:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:70:SELECT import_batch_count = COUNT(*) FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:113:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:123:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:129:INSERT INTO dbo.pb_systems
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:136:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_systems AS existing WHERE existing.SystemId = ss.SystemId);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:138:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:148:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:155:    system_count = (SELECT COUNT(*) FROM dbo.pb_systems),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:156:    system_profile_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:157:    system_profile_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:190:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:195:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:225:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:235:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:241:INSERT INTO dbo.pb_members
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:248:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_members AS existing WHERE existing.MemberId = ms.MemberId);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:250:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:260:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:267:    member_count = (SELECT COUNT(*) FROM dbo.pb_members),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:268:    member_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:269:    member_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:301:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:306:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:329:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:339:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:345:INSERT INTO dbo.pb_privacy_buckets
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:352:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_privacy_buckets AS existing WHERE existing.PrivacyBucketId = pbs.PrivacyBucketId);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:354:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:364:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:371:    privacy_bucket_count = (SELECT COUNT(*) FROM dbo.pb_privacy_buckets),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:372:    privacy_bucket_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:373:    privacy_bucket_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:406:IF NOT EXISTS (SELECT 1 FROM dbo.pb_import_batches WHERE ImportBatchId = @ImportBatchId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:411:IF NOT EXISTS (SELECT 1 FROM dbo.pb_systems WHERE SystemId = @SystemId)
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:434:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:444:    SELECT 1 FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:450:INSERT INTO dbo.pb_custom_fields
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:457:WHERE NOT EXISTS (SELECT 1 FROM dbo.pb_custom_fields AS existing WHERE existing.CustomFieldId = cfs.CustomFieldId);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:459:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:469:    SELECT 1 FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:476:    custom_field_count = (SELECT COUNT(*) FROM dbo.pb_custom_fields),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:477:    custom_field_source_record_count = (SELECT COUNT(*) FROM dbo.pb_source_records WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode),
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:478:    custom_field_source_id_map_count = (SELECT COUNT(*) FROM dbo.pb_source_id_map WHERE SourceSystemCode = @SourceSystemCode AND SourceEntityTypeCode = @SourceEntityTypeCode);
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:501:Target table: dbo.pb_front_history
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:539:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:543:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:548:INSERT INTO dbo.pb_front_history
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:580:    FROM dbo.pb_front_history AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:594:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:620:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:632:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:656:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:660:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:661:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:662:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:706:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:797:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:801:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:879:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:883:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:964:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:968:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1051:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1165:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1169:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1247:  dbo.pb_source_records for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1248:  dbo.pb_source_id_map for SourceEntityTypeCode = NOTE
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1296:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1300:    INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1367:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1393:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1412:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1436:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1441:SELECT 'NOTE source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1442:SELECT 'NOTE source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'NOTE';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1468:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1469:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CATEGORY
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1505:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1538:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1564:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1568:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1592:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1597:SELECT 'CHAT_CATEGORY source_records expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1598:SELECT 'CHAT_CATEGORY source_id_map expected 1' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CATEGORY';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1624:  dbo.pb_source_records for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1625:  dbo.pb_source_id_map for SourceEntityTypeCode = CHAT_CHANNEL
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1665:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1698:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1724:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1728:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1752:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1757:SELECT 'CHAT_CHANNEL source_records expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1758:SELECT 'CHAT_CHANNEL source_id_map expected 6' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'CHAT_CHANNEL';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1813:    INNER JOIN dbo.pb_source_id_map AS catmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1817:    INNER JOIN dbo.pb_source_id_map AS chanmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1881:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1882:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1961:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1987:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1991:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2015:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2020:SELECT 'EXTERNAL_VIEWER source_records expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2021:SELECT 'EXTERNAL_VIEWER source_id_map expected 2' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2063:  dbo.pb_source_records for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2064:  dbo.pb_source_id_map for SourceEntityTypeCode = SYSTEM_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2101:    INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2138:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2164:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2168:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2192:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2197:SELECT 'SYSTEM_PROFILE_FIELD source_records expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2198:SELECT 'SYSTEM_PROFILE_FIELD source_id_map expected 7' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'SYSTEM_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2226:  dbo.pb_source_records for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2227:  dbo.pb_source_id_map for SourceEntityTypeCode = EXTERNAL_VIEWER_PROFILE_FIELD
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2264:    INNER JOIN dbo.pb_source_id_map AS viewer_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2301:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2327:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2331:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2355:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2360:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_records expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2361:SELECT 'EXTERNAL_VIEWER_PROFILE_FIELD source_id_map expected 14' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'EXTERNAL_VIEWER_PROFILE_FIELD';
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:25:FROM [PluralBridge].dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:30:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:38:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:25:FROM [PluralBridge].dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:30:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:38:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:25:FROM [PluralBridge].dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:30:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:38:FROM [PluralBridge].dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089n_diagnose_repeatbuild_target_state.sql:6:SELECT COUNT(*) AS RepeatBuildFrontHistoryRows FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089n_diagnose_repeatbuild_target_state.sql:9:SELECT COUNT(*) AS RepeatBuildFrontHistorySourceRecords FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089n_diagnose_repeatbuild_target_state.sql:12:SELECT COUNT(*) AS RepeatBuildFrontHistorySourceMaps FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089n_diagnose_repeatbuild_target_state.sql:15:SELECT SourceSystemCode, SourceEntityTypeCode, COUNT(*) AS MapRows FROM dbo.pb_source_id_map GROUP BY SourceSystemCode, SourceEntityTypeCode ORDER BY SourceSystemCode, SourceEntityTypeCode;
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:56:INNER JOIN dbo.pb_source_id_map AS sysmap
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:60:INNER JOIN dbo.pb_source_id_map AS membermap
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:68:INSERT INTO dbo.pb_front_history
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:100:    FROM dbo.pb_front_history AS existing
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:104:INSERT INTO dbo.pb_source_records
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:130:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:136:    FROM dbo.pb_source_records AS existing
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:142:INSERT INTO dbo.pb_source_id_map
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:166:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:172:    FROM dbo.pb_source_id_map AS existing
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:178:SELECT 'pb_front_history expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_front_history;
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:179:SELECT 'FRONT_HISTORY source_records expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_records WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:180:SELECT 'FRONT_HISTORY source_id_map expected 886' AS CheckName, COUNT(*) AS ActualCount FROM dbo.pb_source_id_map WHERE SourceSystemCode = N'APPARYLLIS' AND SourceEntityTypeCode = N'FRONT_HISTORY';
+database/tracking/recovery_workflow_steps_089t_create_003_custom_field_privacy_bucket_segment_corrected.sql:39:    INNER JOIN dbo.pb_source_id_map AS fieldmap
+database/tracking/recovery_workflow_steps_089t_create_003_custom_field_privacy_bucket_segment_corrected.sql:43:    INNER JOIN dbo.pb_source_id_map AS bucketmap
+
+LOCAL-ONLY HITS
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:8:USE [master];
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:11:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:13:    ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:16:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:20:DBCC CLONEDATABASE (N'PluralBridge', N'PluralBridge_RepeatBuild');
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:23:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:27:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:37:WHERE name = N'PluralBridge_RepeatBuild';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:40:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:86:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:89:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:99:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:100:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:101:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:102:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:103:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:104:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:105:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:106:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:107:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:108:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:157:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:179:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:240:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:251:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:288:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:350:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:360:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:389:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:450:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:461:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:491:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:553:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:588:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate/pop_candidate_one_script_001_local_repeatbuild_001_006.sql:747:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:3:USE [master];
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:6:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:8:    ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:11:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:15:DBCC CLONEDATABASE (N'PluralBridge', N'PluralBridge_RepeatBuild');
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:18:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:22:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:32:WHERE name = N'PluralBridge_RepeatBuild';
+database/targeting/prop_candidate/pop_candidate_step_002_create_repeatbuild_database.sql:35:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_step_006_validate_001_006_slice.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:8:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:11:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:21:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:22:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:23:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:24:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:79:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:101:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:162:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:173:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:210:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:272:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:282:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:311:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:372:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:383:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:413:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:475:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:510:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate/private_export/private_export_step_001_export_001_006_as_json.sql:2:-- Run in SSMS with PluralBridge_RepeatBuild selected/highlighted.
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:11:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:14:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:24:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:82:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:104:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:165:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:176:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:213:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:275:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:285:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:314:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:375:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:386:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:416:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:504:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:3:USE [master];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:6:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:8:    ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:11:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:15:DBCC CLONEDATABASE (N'PluralBridge', N'PluralBridge_RepeatBuild');
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:18:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:22:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:32:WHERE name = N'PluralBridge_RepeatBuild';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_002_create_repeatbuild_database.sql:35:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_006_validate_001_006_slice.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:11:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:14:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:24:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:82:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:104:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:165:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:176:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:213:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:275:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:285:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:314:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:375:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:386:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:416:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_008_003_populate_from_prequel_001_006_candidate_fixed_target_db.sql:504:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_011_seed_source_systems_from_baseline.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:8:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:11:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:21:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:22:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:23:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:24:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:79:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:101:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:162:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:173:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:210:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:272:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:282:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:311:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:372:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:383:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:413:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:475:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_014_003_populate_from_prequel_001_006_candidate_firstpass_fixed.sql:510:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:2:USE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:11:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:14:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:24:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:82:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:104:FROM [PluralBridge-Prequel].dbo.me AS me
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:165:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:176:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:213:FROM [PluralBridge-Prequel].dbo.members AS m
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:275:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:285:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:314:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:375:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:386:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:416:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_003_populate_from_prequel_001_006_candidate_fixed_front_history_batch.sql:509:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:2:USE [master];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:4:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:6:    ALTER DATABASE [PluralBridge_RepeatBuild] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:7:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:10:CREATE DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:12:ALTER DATABASE [PluralBridge_RepeatBuild] SET MULTI_USER;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_017_create_empty_repeatbuild_database.sql:16:WHERE name = N'PluralBridge_RepeatBuild';
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:2:USE [master];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:4:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:6:    ALTER DATABASE [PluralBridge_RepeatBuild] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:7:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:10:CREATE DATABASE [PluralBridge_RepeatBuild];
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:12:ALTER DATABASE [PluralBridge_RepeatBuild] SET MULTI_USER;
+database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_019_create_empty_repeatbuild_database.sql:16:WHERE name = N'PluralBridge_RepeatBuild';
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:2:-- Run in SSMS with PluralBridge_RepeatBuild selected/highlighted.
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_001_generate_private_001_006_insert_lines.sql:7:SELECT ScriptLine = N'-- Private 1-6 data insert script generated from PluralBridge_RepeatBuild';
+database/targeting/prop_candidate_fail_20260606_private_export_insert_text/pop_candidate_export_003_generate_private_parent_inserts.sql:2:-- Run in SSMS with PluralBridge_RepeatBuild selected/highlighted.
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:2:USE [PluralBridge_RepeatBuild];
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:11:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:14:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:24:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:82:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:104:FROM [PluralBridge-Prequel].dbo.me AS me
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:165:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:176:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:213:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:275:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:285:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:314:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:375:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:386:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:416:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/pop_candidate/pop_candidate_step_001_003_populate_from_prequel_001_006_candidate.sql:504:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:6:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:9:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:19:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:20:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:21:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:22:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:23:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:24:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:25:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:26:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:27:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_025_create_003_header_segment.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:9:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_027_create_003_system_segment.sql:31:FROM [PluralBridge-Prequel].dbo.me AS me
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:8:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:19:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_031_create_003_member_segment.sql:56:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:9:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:19:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_033_create_003_privacy_bucket_segment.sql:48:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:8:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:19:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_035_create_003_custom_field_segment.sql:49:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:13:Source table: [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:51:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:105:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_040_create_003_front_history_segment.sql:143:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:29:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:30:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:32:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.members')
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:41:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:49:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:59:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:75:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_041_inspect_member_frames.sql:82:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:29:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:30:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:32:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.members')
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:41:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:49:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:59:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:75:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_042_inspect_member_frames_collation_fixed.sql:82:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_043_inspect_member_frame_table_names.sql:42:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_043_inspect_member_frame_table_names.sql:54:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_045_inspect_member_frame_content_frame.sql:26:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_045_inspect_member_frame_content_frame.sql:32:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_045_inspect_member_frame_content_frame.sql:43:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_045_inspect_member_frame_content_frame.sql:59:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_045_inspect_member_frame_content_frame.sql:67:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_046_inspect_member_frame_corrected_paths.sql:18:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_046_inspect_member_frame_corrected_paths.sql:41:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_046_inspect_member_frame_corrected_paths.sql:87:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_048_create_003_member_frame_segment.sql:8:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_048_create_003_member_frame_segment.sql:36:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:28:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:36:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:45:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:59:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_049_inspect_member_privacy_buckets.sql:75:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_051_create_003_member_privacy_bucket_segment.sql:8:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_051_create_003_member_privacy_bucket_segment.sql:31:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:28:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:36:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:47:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:57:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:71:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_052_inspect_member_custom_field_values.sql:88:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:28:FROM [PluralBridge-Prequel].dbo.members;
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:36:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:47:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:57:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:71:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_053_inspect_member_custom_field_values_fixed.sql:88:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_055_create_003_member_custom_field_value_segment.sql:8:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_055_create_003_member_custom_field_value_segment.sql:35:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.customfields')
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:44:FROM [PluralBridge-Prequel].dbo.customfields;
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:53:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:67:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:79:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_056_inspect_custom_field_privacy_buckets.sql:98:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_058_create_003_custom_field_privacy_bucket_segment.sql:8:Source table: [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_058_create_003_custom_field_privacy_bucket_segment.sql:32:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.member_avatars')
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:54:FROM [PluralBridge-Prequel].dbo.member_avatars;
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:65:FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:72:FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_059_inspect_member_avatar_assets.sql:83:    FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_060_inspect_avatar_timestamp_policy.sql:14:FROM [PluralBridge-Prequel].dbo.member_avatars;
+database/tracking/recovery_workflow_steps_060_inspect_avatar_timestamp_policy.sql:46:FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_062_create_003_member_avatar_asset_segment.sql:10:Source table: [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_062_create_003_member_avatar_asset_segment.sql:41:    FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.member_notes')
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:54:FROM [PluralBridge-Prequel].dbo.member_notes;
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:64:FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:71:FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:82:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_063_inspect_source_note_files.sql:99:FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_065_create_003_source_note_file_segment.sql:13:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_065_create_003_source_note_file_segment.sql:49:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:41:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:84:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:102:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_066_inspect_notes.sql:144:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:13:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:51:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:122:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_068_create_003_note_segment.sql:170:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.chat_categories')
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:45:FROM [PluralBridge-Prequel].dbo.chat_categories;
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:51:FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:61:FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:73:FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:89:FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_069_inspect_chat_categories.sql:97:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:14:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_071_create_003_chat_category_segment.sql:53:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.chat_channels')
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:45:FROM [PluralBridge-Prequel].dbo.chat_channels;
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:51:FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:61:FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:73:FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:90:FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_072_inspect_chat_channels.sql:98:    FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:14:Source table: [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_074_create_003_chat_channel_segment.sql:57:    FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:28:FROM [PluralBridge-Prequel].dbo.chat_categories;
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:38:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:60:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:80:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_075_inspect_chat_category_channels.sql:107:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_077_create_003_chat_category_channel_segment.sql:11:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_077_create_003_chat_category_channel_segment.sql:33:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:49:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:50:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:52:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.friends')
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:69:FROM [PluralBridge-Prequel].dbo.friends;
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:77:FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:87:FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:99:FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:119:FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_078_inspect_external_viewers.sql:127:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_079_inspect_external_viewer_target_baseline.sql:78:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_079_inspect_external_viewer_target_baseline.sql:111:FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:16:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_081_create_003_external_viewer_segment.sql:63:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:30:FROM [PluralBridge-Prequel].sys.columns AS c
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:31:INNER JOIN [PluralBridge-Prequel].sys.types AS t
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:33:WHERE c.object_id = OBJECT_ID(N'[PluralBridge-Prequel].dbo.me')
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:45:FROM [PluralBridge-Prequel].dbo.me;
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:51:FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:61:FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:73:FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:83:FROM [PluralBridge-Prequel].dbo.me;
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:98:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:130:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:150:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_082_inspect_system_profile_fields.sql:167:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:72:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_083_inspect_system_profile_field_target_baseline.sql:110:FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:15:Source table: [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_084_create_003_system_profile_field_segment.sql:44:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:25:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:46:    FROM [PluralBridge-Prequel].dbo.friends AS f CROSS APPLY OPENJSON(f.raw_json, '$.content.fields') AS fields
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:70:    FROM [PluralBridge-Prequel].dbo.friends AS f CROSS APPLY OPENJSON(f.raw_json, '$.content.fields') AS fields
+database/tracking/recovery_workflow_steps_085_inspect_external_viewer_profile_fields.sql:83:    FROM [PluralBridge-Prequel].dbo.friends AS f CROSS APPLY OPENJSON(f.raw_json, '$.content.fields') AS fields
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:15:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_086_create_003_external_viewer_profile_field_segment.sql:44:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:15:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:18:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:28:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:34:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:35:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:36:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:37:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:88:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:110:FROM [PluralBridge-Prequel].dbo.me AS me
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:173:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:184:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:221:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:285:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:295:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:324:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:387:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:398:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:428:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:496:Source table: [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:534:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:588:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:626:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:672:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:700:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:766:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:789:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:843:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:870:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:930:Source table: [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:954:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1010:Source table: [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1041:    FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1118:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1154:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1233:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1271:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1342:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1390:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1453:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1492:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1608:Source table: [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1651:    FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1764:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1786:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1863:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:1910:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2043:Source table: [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2072:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2205:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_087_003_populate_from_prequel_candidate.sql:2234:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:14:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:17:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:27:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:34:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:35:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:36:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:88:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:110:FROM [PluralBridge-Prequel].dbo.me AS me
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:174:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:185:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:222:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:287:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:297:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:326:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:390:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:401:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:431:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:500:Source table: [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:538:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:592:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:630:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:677:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:705:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:772:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:795:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:850:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:877:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:938:Source table: [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:962:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1019:Source table: [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1050:    FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1128:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1164:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1244:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1282:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1353:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1401:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1465:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1504:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1621:Source table: [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1664:    FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1778:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1800:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1878:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:1925:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2059:Source table: [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2088:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2222:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089a_003_populate_from_prequel_candidate_with_go.sql:2251:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:3:USE [master];
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:6:IF DB_ID(NPluralBridge_RepeatBuild) IS NOT NULL
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:8:    ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:11:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:15:DBCC CLONEDATABASE (NPluralBridge, NPluralBridge_RepeatBuild);
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:18:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:22:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:32:WHERE name = NPluralBridge_RepeatBuild;
+database/tracking/recovery_workflow_steps_089b_create_repeatbuild_database.sql:35:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:3:USE [master];
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:6:IF DB_ID(N'PluralBridge_RepeatBuild') IS NOT NULL
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:8:    ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:11:    DROP DATABASE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:15:DBCC CLONEDATABASE (N'PluralBridge', N'PluralBridge_RepeatBuild');
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:18:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:22:ALTER DATABASE [PluralBridge_RepeatBuild]
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:32:WHERE name = N'PluralBridge_RepeatBuild';
+database/tracking/recovery_workflow_steps_089c_create_repeatbuild_database.sql:35:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:14:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:17:DECLARE @ImportNotes nvarchar(max) = N'Repeatable canonical population from preserved PluralBridge-Prequel database.';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:27:    SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:28:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:29:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.privacybuckets
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:30:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:31:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:32:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:33:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:34:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:35:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:36:    UNION ALL SELECT imported_at_utc FROM [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:88:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:110:FROM [PluralBridge-Prequel].dbo.me AS me
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:174:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:185:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:222:FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:287:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:297:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:326:FROM [PluralBridge-Prequel].dbo.privacybuckets AS pb
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:390:DECLARE @SourceExportName nvarchar(500) = N'PluralBridge-Prequel';
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:401:FROM [PluralBridge-Prequel].dbo.me AS me;
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:431:FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:500:Source table: [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:538:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:592:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:630:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:677:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:705:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:772:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:795:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:850:Source table: [PluralBridge-Prequel].dbo.members
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:877:    FROM [PluralBridge-Prequel].dbo.members AS m
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:938:Source table: [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:962:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1019:Source table: [PluralBridge-Prequel].dbo.member_avatars
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1050:    FROM [PluralBridge-Prequel].dbo.member_avatars AS ma
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1128:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1164:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1244:Source table: [PluralBridge-Prequel].dbo.member_notes
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1282:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1353:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1401:    FROM [PluralBridge-Prequel].dbo.member_notes AS mn
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1465:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1504:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1621:Source table: [PluralBridge-Prequel].dbo.chat_channels
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1664:    FROM [PluralBridge-Prequel].dbo.chat_channels AS ch
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1778:Source table: [PluralBridge-Prequel].dbo.chat_categories
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1800:    FROM [PluralBridge-Prequel].dbo.chat_categories AS cc
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1878:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:1925:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2059:Source table: [PluralBridge-Prequel].dbo.me
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2088:    FROM [PluralBridge-Prequel].dbo.me AS m
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2222:Source table: [PluralBridge-Prequel].dbo.friends
+database/tracking/recovery_workflow_steps_089d_003_populate_from_prequel_candidate.sql:2251:    FROM [PluralBridge-Prequel].dbo.friends AS f
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:3:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:9:FROM [PluralBridge-Prequel].dbo.front_history;
+database/tracking/recovery_workflow_steps_089j_diagnose_front_history_duplicates.sql:17:FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:3:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:9:FROM [PluralBridge-Prequel].dbo.front_history;
+database/tracking/recovery_workflow_steps_089k_diagnose_front_history_duplicates_collated.sql:17:FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:3:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:9:FROM [PluralBridge-Prequel].dbo.front_history;
+database/tracking/recovery_workflow_steps_089l_diagnose_front_history_duplicates_fixed_quotes.sql:17:FROM [PluralBridge-Prequel].dbo.front_history
+database/tracking/recovery_workflow_steps_089n_diagnose_repeatbuild_target_state.sql:3:USE [PluralBridge_RepeatBuild];
+database/tracking/recovery_workflow_steps_089q_create_003_front_history_segment_corrected.sql:35:    FROM [PluralBridge-Prequel].dbo.front_history AS fh
+database/tracking/recovery_workflow_steps_089t_create_003_custom_field_privacy_bucket_segment_corrected.sql:8:Source table: [PluralBridge-Prequel].dbo.customfields
+database/tracking/recovery_workflow_steps_089t_create_003_custom_field_privacy_bucket_segment_corrected.sql:37:    FROM [PluralBridge-Prequel].dbo.customfields AS cf
+
+CLOUD_STEP_19A_SCHEMA_SOURCE_INVENTORY_COMPLETE

--- a/database/targeting/prop_candidate/cloud/cloud_step_020a_schema_candidate_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_020a_schema_candidate_audit.md
@@ -1,0 +1,24 @@
+# Cloud Step 20A Azure Schema Candidate Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD: 1fba552
+- Azure write check before this step: READ_WRITE, CanCreateTable = 1, CanAlterDatabase = 1
+
+## Decision
+
+Schema inventory found the 1-6 pb_* table/constraint shape in an archived failed candidate folder.
+
+The archived SQL file is not executed directly. A fresh Azure-target candidate was generated under database/targeting/prop_candidate/cloud/.
+
+## Files
+
+- Schema reference inspected: database/targeting/prop_candidate_fail_20260606_112536/pop_candidate_step_021_create_001_006_schema_idempotent.sql
+- Generated Azure schema candidate: database/targeting/prop_candidate/cloud/cloud_step_020_create_azure_schema_001_006.sql
+
+## Boundary
+
+No SQL was executed by Git Bash. Azure SQL DDL execution remains SSMS-only.

--- a/database/targeting/prop_candidate/cloud/cloud_step_020b_create_azure_schema_001_006.sql
+++ b/database/targeting/prop_candidate/cloud/cloud_step_020b_create_azure_schema_001_006.sql
@@ -1,0 +1,272 @@
+-- Cloud Step 20B start
+-- Azure SQL 1-6 schema candidate, fixed SQL string quoting.
+-- Run in SSMS against PluralBridgeCloudProof001 on pluralbridge-cloudproof-syf001.database.windows.net.
+-- Requires the target database to be empty of the pb_* tables listed below.
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM sys.tables AS t
+    WHERE t.name IN
+    (
+        N'pb_source_systems',
+        N'pb_import_batches',
+        N'pb_systems',
+        N'pb_members',
+        N'pb_privacy_buckets',
+        N'pb_custom_fields',
+        N'pb_front_history',
+        N'pb_source_records',
+        N'pb_source_id_map'
+    )
+)
+BEGIN
+    THROW 51000, 'Target database already has one or more PluralBridge 1-6 pb_* tables. Stop before schema creation.', 1;
+END
+
+BEGIN TRANSACTION;
+
+-- Step 21 start
+SET NOCOUNT ON;
+
+IF OBJECT_ID(N'dbo.pb_source_systems', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_source_systems
+    (
+        SourceSystemCode nvarchar(64) NOT NULL,
+        DisplayName nvarchar(510) NOT NULL,
+        Description nvarchar(max) NULL,
+        ApiBaseUrl nvarchar(2000) NULL,
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        CONSTRAINT PK_pb_source_systems PRIMARY KEY CLUSTERED (SourceSystemCode)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_import_batches', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_import_batches
+    (
+        ImportBatchId uniqueidentifier NOT NULL CONSTRAINT DF_pb_import_batches_ImportBatchId DEFAULT (newsequentialid()),
+        SourceSystemCode nvarchar(64) NOT NULL,
+        ImportStartedAtUtc datetime2(3) NOT NULL,
+        ImportCompletedAtUtc datetime2(3) NULL,
+        ImportToolName nvarchar(510) NULL,
+        ImportToolVersion nvarchar(128) NULL,
+        SourceExportName nvarchar(1000) NULL,
+        SourceExportSha256 varbinary(32) NULL,
+        Notes nvarchar(max) NULL,
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_import_batches_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        CONSTRAINT PK_pb_import_batches PRIMARY KEY CLUSTERED (ImportBatchId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_systems', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_systems
+    (
+        SystemId uniqueidentifier NOT NULL CONSTRAINT DF_pb_systems_SystemId DEFAULT (newsequentialid()),
+        SystemName nvarchar(510) NULL,
+        Description nvarchar(max) NULL,
+        Color nvarchar(64) NULL,
+        AvatarUrl nvarchar(2000) NULL,
+        AvatarUuid nvarchar(128) NULL,
+        SourceCreatedAtMs bigint NULL,
+        LastOperationTimeMs bigint NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_systems_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        UpdatedAtUtc datetime2(3) NULL,
+        CONSTRAINT PK_pb_systems PRIMARY KEY CLUSTERED (SystemId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_members', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_members
+    (
+        MemberId uniqueidentifier NOT NULL CONSTRAINT DF_pb_members_MemberId DEFAULT (newsequentialid()),
+        SystemId uniqueidentifier NOT NULL,
+        DisplayName nvarchar(510) NOT NULL,
+        Pronouns nvarchar(510) NULL,
+        Description nvarchar(max) NULL,
+        Color nvarchar(64) NULL,
+        IsArchived bit NULL,
+        ArchivedReason nvarchar(max) NULL,
+        IsPrivate bit NULL,
+        PreventTrusted bit NULL,
+        PreventsFrontNotifications bit NULL,
+        ReceiveMessageBoardNotifications bit NULL,
+        SupportsDescriptionMarkdown bit NULL,
+        LastOperationTimeMs bigint NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_members_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        UpdatedAtUtc datetime2(3) NULL,
+        CONSTRAINT PK_pb_members PRIMARY KEY CLUSTERED (MemberId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_privacy_buckets', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_privacy_buckets
+    (
+        PrivacyBucketId uniqueidentifier NOT NULL CONSTRAINT DF_pb_privacy_buckets_PrivacyBucketId DEFAULT (newsequentialid()),
+        SystemId uniqueidentifier NOT NULL,
+        BucketName nvarchar(510) NOT NULL,
+        Description nvarchar(max) NULL,
+        Color nvarchar(64) NULL,
+        Icon nvarchar(510) NULL,
+        RankText nvarchar(128) NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_privacy_buckets_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        UpdatedAtUtc datetime2(3) NULL,
+        CONSTRAINT PK_pb_privacy_buckets PRIMARY KEY CLUSTERED (PrivacyBucketId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_custom_fields', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_custom_fields
+    (
+        CustomFieldId uniqueidentifier NOT NULL CONSTRAINT DF_pb_custom_fields_CustomFieldId DEFAULT (newsequentialid()),
+        SystemId uniqueidentifier NOT NULL,
+        FieldName nvarchar(510) NOT NULL,
+        Description nvarchar(max) NULL,
+        FieldTypeCode int NULL,
+        DisplayOrderText nvarchar(128) NULL,
+        SupportsMarkdown bit NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_custom_fields_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        UpdatedAtUtc datetime2(3) NULL,
+        CONSTRAINT PK_pb_custom_fields PRIMARY KEY CLUSTERED (CustomFieldId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_front_history', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_front_history
+    (
+        FrontHistoryId uniqueidentifier NOT NULL CONSTRAINT DF_pb_front_history_FrontHistoryId DEFAULT (newsequentialid()),
+        SystemId uniqueidentifier NOT NULL,
+        MemberId uniqueidentifier NOT NULL,
+        StartTimeMs bigint NOT NULL,
+        EndTimeMs bigint NULL,
+        IsLive bit NULL,
+        IsCustom bit NULL,
+        CustomStatus nvarchar(510) NULL,
+        LastOperationTimeMs bigint NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_front_history_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        UpdatedAtUtc datetime2(3) NULL,
+        CONSTRAINT PK_pb_front_history PRIMARY KEY CLUSTERED (FrontHistoryId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_source_records', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_source_records
+    (
+        SourceRecordId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_records_SourceRecordId DEFAULT (newsequentialid()),
+        ImportBatchId uniqueidentifier NOT NULL,
+        SourceSystemCode nvarchar(64) NOT NULL,
+        SourceEntityTypeCode nvarchar(128) NOT NULL,
+        SourceId nvarchar(256) NULL,
+        SourceEndpoint nvarchar(2000) NULL,
+        RawJson nvarchar(max) NULL,
+        RawJsonSha256 varbinary(32) NULL,
+        ImportedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_records_ImportedAtUtc DEFAULT (sysutcdatetime()),
+        CONSTRAINT PK_pb_source_records PRIMARY KEY CLUSTERED (SourceRecordId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.pb_source_id_map', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.pb_source_id_map
+    (
+        SourceIdMapId uniqueidentifier NOT NULL CONSTRAINT DF_pb_source_id_map_SourceIdMapId DEFAULT (newsequentialid()),
+        SourceSystemCode nvarchar(64) NOT NULL,
+        SourceEntityTypeCode nvarchar(128) NOT NULL,
+        SourceId nvarchar(256) NOT NULL,
+        PluralBridgeEntityTypeCode nvarchar(128) NOT NULL,
+        PluralBridgeId uniqueidentifier NOT NULL,
+        ImportBatchId uniqueidentifier NOT NULL,
+        CreatedAtUtc datetime2(3) NOT NULL CONSTRAINT DF_pb_source_id_map_CreatedAtUtc DEFAULT (sysutcdatetime()),
+        CONSTRAINT PK_pb_source_id_map PRIMARY KEY CLUSTERED (SourceIdMapId),
+        CONSTRAINT UQ_pb_source_id_map_SourceIdentity UNIQUE NONCLUSTERED (SourceSystemCode, SourceEntityTypeCode, SourceId)
+    );
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_import_batches_pb_source_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_import_batches ADD CONSTRAINT FK_pb_import_batches_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_members_pb_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_members ADD CONSTRAINT FK_pb_members_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_privacy_buckets_pb_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_privacy_buckets ADD CONSTRAINT FK_pb_privacy_buckets_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_custom_fields_pb_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_custom_fields ADD CONSTRAINT FK_pb_custom_fields_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_front_history_pb_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_systems FOREIGN KEY (SystemId) REFERENCES dbo.pb_systems(SystemId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_front_history_pb_members', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_front_history ADD CONSTRAINT FK_pb_front_history_pb_members FOREIGN KEY (MemberId) REFERENCES dbo.pb_members(MemberId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_source_records_pb_import_batches', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_source_records_pb_source_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_source_records ADD CONSTRAINT FK_pb_source_records_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_source_id_map_pb_import_batches', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_import_batches FOREIGN KEY (ImportBatchId) REFERENCES dbo.pb_import_batches(ImportBatchId);
+END;
+
+IF OBJECT_ID(N'dbo.FK_pb_source_id_map_pb_source_systems', N'F') IS NULL
+BEGIN
+    ALTER TABLE dbo.pb_source_id_map ADD CONSTRAINT FK_pb_source_id_map_pb_source_systems FOREIGN KEY (SourceSystemCode) REFERENCES dbo.pb_source_systems(SourceSystemCode);
+END;
+
+SELECT PbTableCount = COUNT(*) FROM sys.tables WHERE name LIKE NCHAR(112)+NCHAR(98)+NCHAR(95)+NCHAR(37);
+-- Step 21 end
+
+COMMIT TRANSACTION;
+
+SELECT
+    t.name AS CreatedPluralBridgeTable
+FROM sys.tables AS t
+WHERE t.name IN
+(
+    N'pb_source_systems',
+    N'pb_import_batches',
+    N'pb_systems',
+    N'pb_members',
+    N'pb_privacy_buckets',
+    N'pb_custom_fields',
+    N'pb_front_history',
+    N'pb_source_records',
+    N'pb_source_id_map'
+)
+ORDER BY t.name;
+
+-- Cloud Step 20B end

--- a/database/targeting/prop_candidate/cloud/cloud_step_020b_schema_candidate_fix_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_020b_schema_candidate_fix_audit.md
@@ -1,0 +1,21 @@
+# Cloud Step 20B Schema Candidate Fix Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD: 1fba552
+
+## Failure
+
+- Failed SQL file: cloud_step_020_create_azure_schema_001_006.sql
+- SSMS error: Msg 102, incorrect syntax near Target.
+- Cause: Bash generation stripped quotes from the THROW message text.
+- SQL failed before BEGIN TRANSACTION; expected Azure target state remains unchanged.
+
+## Fix
+
+- Failed SQL archived under database/targeting/prop_candidate_fail_20260606_cloud_schema_throw_quote_error/.
+- Replacement SQL: database/targeting/prop_candidate/cloud/cloud_step_020b_create_azure_schema_001_006.sql
+- DDL execution remains SSMS-only.

--- a/database/targeting/prop_candidate/cloud/cloud_step_020c_azure_schema_execution_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_020c_azure_schema_execution_audit.md
@@ -1,0 +1,40 @@
+# Cloud Step 20C Azure Schema Execution Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD: 1fba552
+- Execution surface: SSMS against Azure SQL
+- Server: pluralbridge-cloudproof-syf001.database.windows.net
+- Database: PluralBridgeCloudProof001
+
+## Script executed
+
+- Executed SQL file: database/targeting/prop_candidate/cloud/cloud_step_020b_create_azure_schema_001_006.sql
+- Prior failed SQL file was archived under database/targeting/prop_candidate_fail_20260606_cloud_schema_throw_quote_error/.
+
+## Result
+
+- Schema creation passed in Azure SQL.
+- PBTableCount result: 9
+- Created tables:
+  - pb_custom_fields
+  - pb_front_history
+  - pb_import_batches
+  - pb_members
+  - pb_privacy_buckets
+  - pb_source_id_map
+  - pb_source_records
+  - pb_source_systems
+  - pb_systems
+
+## Boundary
+
+- No private JSON files were staged or committed.
+- No data import has been run against Azure SQL yet.
+
+## Next action
+
+Run an Azure schema validation SQL file to confirm table, column, primary key, foreign key, and unique constraint shape before any data load.

--- a/database/targeting/prop_candidate/cloud/cloud_step_021_validate_azure_schema_001_006.sql
+++ b/database/targeting/prop_candidate/cloud/cloud_step_021_validate_azure_schema_001_006.sql
@@ -1,0 +1,119 @@
+-- Cloud Step 21 start
+-- Azure SQL read-only schema validation for 1-6 pb_* proof tables.
+-- Run in SSMS against PluralBridgeCloudProof001 on pluralbridge-cloudproof-syf001.database.windows.net.
+
+SET NOCOUNT ON;
+
+DECLARE @ExpectedTables TABLE (TableName sysname NOT NULL PRIMARY KEY);
+INSERT INTO @ExpectedTables (TableName)
+VALUES
+    (N'pb_source_systems'),
+    (N'pb_import_batches'),
+    (N'pb_systems'),
+    (N'pb_members'),
+    (N'pb_privacy_buckets'),
+    (N'pb_custom_fields'),
+    (N'pb_front_history'),
+    (N'pb_source_records'),
+    (N'pb_source_id_map');
+
+DECLARE @ExpectedCoreColumns TABLE (TableName sysname NOT NULL, ColumnName sysname NOT NULL, PRIMARY KEY (TableName, ColumnName));
+INSERT INTO @ExpectedCoreColumns (TableName, ColumnName)
+VALUES
+    (N'pb_source_systems', N'SourceSystemCode'),
+    (N'pb_import_batches', N'ImportBatchId'),
+    (N'pb_import_batches', N'SourceSystemCode'),
+    (N'pb_systems', N'SystemId'),
+    (N'pb_members', N'MemberId'),
+    (N'pb_members', N'SystemId'),
+    (N'pb_privacy_buckets', N'PrivacyBucketId'),
+    (N'pb_privacy_buckets', N'SystemId'),
+    (N'pb_custom_fields', N'CustomFieldId'),
+    (N'pb_custom_fields', N'SystemId'),
+    (N'pb_front_history', N'FrontHistoryId'),
+    (N'pb_front_history', N'SystemId'),
+    (N'pb_front_history', N'MemberId'),
+    (N'pb_source_records', N'SourceRecordId'),
+    (N'pb_source_records', N'ImportBatchId'),
+    (N'pb_source_records', N'SourceSystemCode'),
+    (N'pb_source_id_map', N'SourceIdMapId'),
+    (N'pb_source_id_map', N'ImportBatchId'),
+    (N'pb_source_id_map', N'SourceSystemCode'),
+    (N'pb_source_id_map', N'SourceEntityTypeCode'),
+    (N'pb_source_id_map', N'SourceId');
+
+DECLARE @ExpectedConstraints TABLE (ConstraintName sysname NOT NULL PRIMARY KEY, ConstraintKind nvarchar(20) NOT NULL);
+INSERT INTO @ExpectedConstraints (ConstraintName, ConstraintKind)
+VALUES
+    (N'PK_pb_source_systems', N'PK'),
+    (N'PK_pb_import_batches', N'PK'),
+    (N'PK_pb_systems', N'PK'),
+    (N'PK_pb_members', N'PK'),
+    (N'PK_pb_privacy_buckets', N'PK'),
+    (N'PK_pb_custom_fields', N'PK'),
+    (N'PK_pb_front_history', N'PK'),
+    (N'PK_pb_source_records', N'PK'),
+    (N'PK_pb_source_id_map', N'PK'),
+    (N'UQ_pb_source_id_map_SourceIdentity', N'UQ'),
+    (N'FK_pb_import_batches_pb_source_systems', N'FK'),
+    (N'FK_pb_members_pb_systems', N'FK'),
+    (N'FK_pb_privacy_buckets_pb_systems', N'FK'),
+    (N'FK_pb_custom_fields_pb_systems', N'FK'),
+    (N'FK_pb_front_history_pb_systems', N'FK'),
+    (N'FK_pb_front_history_pb_members', N'FK'),
+    (N'FK_pb_source_records_pb_import_batches', N'FK'),
+    (N'FK_pb_source_records_pb_source_systems', N'FK'),
+    (N'FK_pb_source_id_map_pb_import_batches', N'FK'),
+    (N'FK_pb_source_id_map_pb_source_systems', N'FK');
+
+WITH ActualTables AS
+(
+    SELECT t.name AS TableName
+    FROM sys.tables AS t
+    WHERE t.name LIKE N'pb[_]%'
+),
+ActualConstraints AS
+(
+    SELECT kc.name AS ConstraintName, kc.type AS ConstraintKind
+    FROM sys.key_constraints AS kc
+    UNION ALL
+    SELECT fk.name AS ConstraintName, N'FK' AS ConstraintKind
+    FROM sys.foreign_keys AS fk
+)
+SELECT CheckName, ExpectedValue, ActualValue, Result
+FROM
+(
+    SELECT N'Database' AS CheckName, N'PluralBridgeCloudProof001' AS ExpectedValue, CONVERT(nvarchar(200), DB_NAME()) AS ActualValue, CASE WHEN DB_NAME() = N'PluralBridgeCloudProof001' THEN N'PASS' ELSE N'FAIL' END AS Result
+    UNION ALL
+    SELECT N'pb_* table count', N'9', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 9 THEN N'PASS' ELSE N'FAIL' END FROM ActualTables
+    UNION ALL
+    SELECT N'Missing expected tables', N'0', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 0 THEN N'PASS' ELSE N'FAIL' END FROM @ExpectedTables AS e LEFT JOIN ActualTables AS a ON a.TableName = e.TableName WHERE a.TableName IS NULL
+    UNION ALL
+    SELECT N'Missing expected core columns', N'0', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 0 THEN N'PASS' ELSE N'FAIL' END FROM @ExpectedCoreColumns AS e LEFT JOIN sys.tables AS t ON t.name = e.TableName LEFT JOIN sys.columns AS c ON c.object_id = t.object_id AND c.name = e.ColumnName WHERE c.object_id IS NULL
+    UNION ALL
+    SELECT N'Primary key count', N'9', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 9 THEN N'PASS' ELSE N'FAIL' END FROM sys.key_constraints WHERE type = N'PK' AND parent_object_id IN (SELECT OBJECT_ID(N'dbo.' + TableName) FROM @ExpectedTables)
+    UNION ALL
+    SELECT N'Foreign key count', N'10', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 10 THEN N'PASS' ELSE N'FAIL' END FROM sys.foreign_keys WHERE parent_object_id IN (SELECT OBJECT_ID(N'dbo.' + TableName) FROM @ExpectedTables)
+    UNION ALL
+    SELECT N'Unique constraint count', N'1', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 1 THEN N'PASS' ELSE N'FAIL' END FROM sys.key_constraints WHERE type = N'UQ' AND parent_object_id IN (SELECT OBJECT_ID(N'dbo.' + TableName) FROM @ExpectedTables)
+    UNION ALL
+    SELECT N'Missing expected constraints', N'0', CONVERT(nvarchar(200), COUNT(*)), CASE WHEN COUNT(*) = 0 THEN N'PASS' ELSE N'FAIL' END FROM @ExpectedConstraints AS e LEFT JOIN ActualConstraints AS a ON a.ConstraintName = e.ConstraintName WHERE a.ConstraintName IS NULL
+) AS checks
+ORDER BY CheckName;
+
+SELECT
+    t.name AS TableName,
+    COUNT(c.column_id) AS ColumnCount
+FROM sys.tables AS t
+INNER JOIN sys.columns AS c ON c.object_id = t.object_id
+WHERE t.name IN (SELECT TableName FROM @ExpectedTables)
+GROUP BY t.name
+ORDER BY t.name;
+
+SELECT
+    ConstraintKind,
+    ConstraintName
+FROM @ExpectedConstraints
+ORDER BY ConstraintKind, ConstraintName;
+
+-- Cloud Step 21 end

--- a/database/targeting/prop_candidate/cloud/cloud_step_021b_azure_schema_validation_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_021b_azure_schema_validation_audit.md
@@ -1,0 +1,43 @@
+# Cloud Step 21B Azure Schema Validation Audit
+
+Date: 2026-06-06 PT
+
+## Checkpoint
+
+- Branch: feature/002-cloud-readiness
+- Local HEAD: 1fba552
+- Execution surface: SSMS against Azure SQL
+- Server: pluralbridge-cloudproof-syf001.database.windows.net
+- Database: PluralBridgeCloudProof001
+- Validation SQL: database/targeting/prop_candidate/cloud/cloud_step_021_validate_azure_schema_001_006.sql
+
+## Validation result
+
+- Database check: PASS
+- pb_* table count: 9 PASS
+- Missing expected tables: 0 PASS
+- Missing expected core columns: 0 PASS
+- Primary key count: 9 PASS
+- Foreign key count: 10 PASS
+- Unique constraint count: 1 PASS
+- Missing expected constraints: 0 PASS
+
+## Column counts
+
+- pb_custom_fields: 10
+- pb_front_history: 12
+- pb_import_batches: 10
+- pb_members: 17
+- pb_privacy_buckets: 10
+- pb_source_id_map: 8
+- pb_source_records: 9
+- pb_source_systems: 5
+- pb_systems: 11
+
+## Result
+
+Cloud Step 21 passed. Azure SQL now has the expected empty 1-6 PluralBridge schema with validated tables, columns, primary keys, foreign keys, and unique constraint.
+
+## Next action
+
+Choose the cloud data-load path. The safest next proof path is to generate an Azure JSON import script from the ignored private JSON files, execute only in SSMS, then validate counts against the known 1-6 totals.

--- a/database/targeting/prop_candidate/cloud/cloud_step_023_azure_private_data_load_audit.md
+++ b/database/targeting/prop_candidate/cloud/cloud_step_023_azure_private_data_load_audit.md
@@ -1,0 +1,27 @@
+# Cloud Step 23 Azure private data load audit
+
+- Step: 22E / 23 audit
+- Branch: feature/002-cloud-readiness
+- Head before audit: 85728c0
+- Azure database: PluralBridgeCloudProof001
+- Executed private SQL file: database/targeting/prop_candidate/private_export/json/cloud_step_022e_load_azure_private_data_001_006.sql
+- Private SQL status: ignored, not for commit
+- Result: PASS
+
+## Count results
+
+| Table | Actual | Expected | Result |
+|---|---:|---:|---|
+| pb_source_systems | 1 | 1 | PASS |
+| pb_import_batches | 1 | 1 | PASS |
+| pb_systems | 1 | 1 | PASS |
+| pb_members | 49 | 49 | PASS |
+| pb_privacy_buckets | 2 | 2 | PASS |
+| pb_custom_fields | 7 | 7 | PASS |
+| pb_front_history | 886 | 886 | PASS |
+| pb_source_records | 945 | 945 | PASS |
+| pb_source_id_map | 945 | 945 | PASS |
+
+## Next action
+
+Checkpoint the Azure 1-6 schema-plus-data proof, excluding ignored private JSON and private generated SQL.


### PR DESCRIPTION
Adds the Azure SQL 1-6 schema proof and private data-load audit checkpoint.

Private JSON and generated private SQL remain ignored.

Proof summary:
- Azure database PluralBridgeCloudProof001 schema validation passed.
- Azure private data load passed.
- All 9 proof tables matched expected counts.
- This completes the database-backed cloud-readiness proof for the validated 1-6 slice.