### PR TITLE
Add Phase 1 app me proof

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,0 +1,62 @@
+:root {
+  color-scheme: light;
+  font-family: Arial, Helvetica, sans-serif;
+  background: #f5f2eb;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.app-card {
+  width: min(760px, 100%);
+  background: #ffffff;
+  border: 1px solid #d8d1c4;
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 18px 45px rgba(31, 41, 51, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 1rem;
+}
+
+.intro {
+  line-height: 1.5;
+}
+
+button {
+  margin: 1rem 0;
+  padding: 0.7rem 1.2rem;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.output-box {
+  min-height: 240px;
+  overflow: auto;
+  padding: 1rem;
+  border-radius: 12px;
+  background: #101820;
+  color: #f7fafc;
+  white-space: pre-wrap;
+}

--- a/app/app.js
+++ b/app/app.js
@@ -1,0 +1,37 @@
+const meResponse = Object.freeze({
+  endpoint: "GET /api/me",
+  contractVersion: "phase-1-me-proof",
+  mode: "static-browser-contract",
+  authenticated: true,
+  user: {
+    userId: "phase1-demo-user",
+    displayName: "Phase 1 Demo User"
+  },
+  system: {
+    systemId: "phase1-demo-system",
+    displayName: "Phase 1 Demo System",
+    sourceSystem: "APPARYLLIS",
+    mappingSource: "phase-1-mock-contract"
+  },
+  permissions: {
+    readOnly: true,
+    canReadMembers: true,
+    canReadFrontHistory: true,
+    canWrite: false
+  },
+  dataScope: {
+    source: "mock-contract",
+    usesPrivateData: false
+  },
+  links: {
+    members: "/api/members",
+    frontHistory: "/api/front-history"
+  }
+});
+
+function renderMeResponse() {
+  const output = document.getElementById("meOutput");
+  output.textContent = JSON.stringify(meResponse, null, 2);
+}
+
+document.getElementById("meButton").addEventListener("click", renderMeResponse);

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PluralBridge App</title>
+  <link rel="stylesheet" href="./app.css">
+</head>
+<body>
+  <main class="app-shell">
+    <section class="app-card" aria-labelledby="app-title">
+      <p class="eyebrow">PluralBridge application proof</p>
+      <h1 id="app-title">Phase 1: me endpoint contract</h1>
+      <p class="intro">This app surface is separate from the marketing website and is reserved for the browser application path.</p>
+      <button id="meButton" type="button">me</button>
+      <pre id="meOutput" class="output-box" aria-live="polite">{ }</pre>
+    </section>
+  </main>
+  <script src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds the initial separate PluralBridge app surface under app/.

Phase 1 scope:
- Static app shell
- me button
- output box
- mock planned-contract GET /api/me JSON response
- no private data
- no mutation path

Browser smoke test passed locally.