### PR TITLE
Release GitGem discovery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PluralBridge
 
+[![GitGem](https://gitgem.org/api/badge/github/needsofmany/PluralBridge.svg)](https://gitgem.org/gem/github/needsofmany/PluralBridge)
+
 Project website: https://thepluralbridge.org/
 
 ## Regular users: start here


### PR DESCRIPTION
## Summary

Releases the GitGem discovery badge addition from `dev` into `master`.

Included change:

- Adds the GitGem discovery badge near the top of `README.md`

## Verification

Checked the README top section locally and confirmed the badge appears directly under the project title.