### PR TITLE
Release app Phase 2 read-only surface proof

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,12 +1,18 @@
 :root {
-  color-scheme: light;
-  font-family: Arial, Helvetica, sans-serif;
-  background: #f5f2eb;
-  color: #1f2933;
+  color-scheme: dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101418;
+  color: #f4f7fb;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #243447, #101418 55%);
 }
 
 .app-shell {
@@ -14,49 +20,71 @@ body {
   display: grid;
   place-items: center;
   padding: 2rem;
-  box-sizing: border-box;
 }
 
 .app-card {
-  width: min(760px, 100%);
-  background: #ffffff;
-  border: 1px solid #d8d1c4;
-  border-radius: 18px;
+  width: min(960px, 100%);
   padding: 2rem;
-  box-shadow: 0 18px 45px rgba(31, 41, 51, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 1.25rem;
+  background: rgba(16, 20, 24, 0.86);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
 }
 
 .eyebrow {
   margin: 0 0 0.5rem;
-  font-size: 0.82rem;
+  color: #a8c7ff;
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 h1 {
   margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
 }
 
-.intro {
-  line-height: 1.5;
+p {
+  max-width: 70ch;
+  color: #d8e1ed;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
 }
 
 button {
-  margin: 1rem 0;
-  padding: 0.7rem 1.2rem;
   border: 0;
   border-radius: 999px;
-  cursor: pointer;
+  padding: 0.75rem 1rem;
+  color: #101418;
+  background: #a8c7ff;
+  font: inherit;
   font-weight: 700;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus-visible,
+button[aria-pressed="true"] {
+  background: #f4f7fb;
+  outline: 2px solid #a8c7ff;
+  outline-offset: 3px;
 }
 
 .output-box {
-  min-height: 240px;
+  min-height: 22rem;
   overflow: auto;
+  margin: 0;
   padding: 1rem;
-  border-radius: 12px;
-  background: #101820;
-  color: #f7fafc;
-  white-space: pre-wrap;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.8rem;
+  background: #070a0d;
+  color: #d8e1ed;
+  font-size: 0.92rem;
 }

--- a/app/app.js
+++ b/app/app.js
@@ -1,37 +1,119 @@
-const meResponse = Object.freeze({
-  endpoint: "GET /api/me",
-  contractVersion: "phase-1-me-proof",
-  mode: "static-browser-contract",
-  authenticated: true,
-  user: {
-    userId: "phase1-demo-user",
-    displayName: "Phase 1 Demo User"
+const contracts = {
+  me: {
+    endpoint: "GET /api/me",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      userId: "demo-user-001",
+      displayName: "Phase 2 Demo User",
+      activeSystemId: "demo-system-001"
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
   },
   system: {
-    systemId: "phase1-demo-system",
-    displayName: "Phase 1 Demo System",
-    sourceSystem: "APPARYLLIS",
-    mappingSource: "phase-1-mock-contract"
+    endpoint: "GET /api/systems/current",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      systemId: "demo-system-001",
+      displayName: "Phase 2 Demo System",
+      totalCount: 1
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
   },
-  permissions: {
-    readOnly: true,
-    canReadMembers: true,
-    canReadFrontHistory: true,
-    canWrite: false
+  members: {
+    endpoint: "GET /api/members",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      totalCount: 49,
+      sampleItems: [
+        { memberId: "demo-member-001", displayName: "Demo Member 001" },
+        { memberId: "demo-member-002", displayName: "Demo Member 002" },
+        { memberId: "demo-member-003", displayName: "Demo Member 003" }
+      ]
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
   },
-  dataScope: {
-    source: "mock-contract",
-    usesPrivateData: false
+  frontHistory: {
+    endpoint: "GET /api/front-history",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      totalCount: 886,
+      sampleItems: [
+        { frontHistoryId: "demo-front-001", memberId: "demo-member-001", startedAtUtc: "2026-01-01T00:00:00Z" },
+        { frontHistoryId: "demo-front-002", memberId: "demo-member-002", startedAtUtc: "2026-01-02T00:00:00Z" }
+      ]
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
   },
-  links: {
-    members: "/api/members",
-    frontHistory: "/api/front-history"
+  privacyBuckets: {
+    endpoint: "GET /api/privacy-buckets",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      totalCount: 2,
+      sampleItems: [
+        { privacyBucketId: "demo-privacy-001", label: "Demo Public" },
+        { privacyBucketId: "demo-privacy-002", label: "Demo Trusted" }
+      ]
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
+  },
+  customFields: {
+    endpoint: "GET /api/custom-fields",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      totalCount: 7,
+      sampleItems: [
+        { customFieldId: "demo-field-001", fieldName: "Demo Field 001" },
+        { customFieldId: "demo-field-002", fieldName: "Demo Field 002" }
+      ]
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
+  },
+  importMetadata: {
+    endpoint: "GET /api/imports/current",
+    contractVersion: "phase-2-readonly-surface",
+    data: {
+      sourceSystems: 1,
+      importBatches: 1,
+      sourceRecords: 945,
+      sourceIdMap: 945
+    },
+    safety: {
+      canWrite: false,
+      usesPrivateData: false
+    }
   }
-});
+};
 
-function renderMeResponse() {
-  const output = document.getElementById("meOutput");
-  output.textContent = JSON.stringify(meResponse, null, 2);
+const output = document.getElementById("appOutput");
+const buttons = document.querySelectorAll("[data-contract]");
+
+function renderContract(key) {
+  output.textContent = JSON.stringify(contracts[key], null, 2);
+  buttons.forEach((button) => {
+    button.setAttribute("aria-pressed", String(button.dataset.contract === key));
+  });
 }
 
-document.getElementById("meButton").addEventListener("click", renderMeResponse);
+buttons.forEach((button) => {
+  button.addEventListener("click", () => renderContract(button.dataset.contract));
+});
+
+renderContract("me");

--- a/app/index.html
+++ b/app/index.html
@@ -7,13 +7,21 @@
   <link rel="stylesheet" href="./app.css">
 </head>
 <body>
-  <main class="app-shell">
-    <section class="app-card" aria-labelledby="app-title">
+  <main class="app-shell" aria-labelledby="app-title">
+    <section class="app-card">
       <p class="eyebrow">PluralBridge application proof</p>
-      <h1 id="app-title">Phase 1: me endpoint contract</h1>
-      <p class="intro">This app surface is separate from the marketing website and is reserved for the browser application path.</p>
-      <button id="meButton" type="button">me</button>
-      <pre id="meOutput" class="output-box" aria-live="polite">{ }</pre>
+      <h1 id="app-title">Phase 2: read-only data surface contract</h1>
+      <p>Static planned-contract responses for the validated 1-6 slice. No login, no API connection, no private data, no write path.</p>
+      <div class="button-row" aria-label="Read-only contract actions">
+        <button type="button" data-contract="me">me</button>
+        <button type="button" data-contract="system">system</button>
+        <button type="button" data-contract="members">members</button>
+        <button type="button" data-contract="frontHistory">front history</button>
+        <button type="button" data-contract="privacyBuckets">privacy buckets</button>
+        <button type="button" data-contract="customFields">custom fields</button>
+        <button type="button" data-contract="importMetadata">import metadata</button>
+      </div>
+      <pre id="appOutput" class="output-box" aria-live="polite">{ }</pre>
     </section>
   </main>
   <script src="./app.js"></script>


### PR DESCRIPTION
Releases the Phase 2 browser application proof to master.

Scope:
- Adds the expanded read-only app surface under app/.
- Provides static planned-contract responses for me, system, members, front history, privacy buckets, custom fields, and import metadata.
- Keeps the application proof browser-only with no login, no API connection, no private data, and no write path.

Validation:
- Feature branch merged cleanly into dev.
- Local dev synced to 04fb0f1.
- Browser smoke test passed for all seven buttons.