### PR TITLE
Add app Phase 3 login contract proof

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -88,3 +88,42 @@ button[aria-pressed="true"] {
   color: #d8e1ed;
   font-size: 0.92rem;
 }
+
+.login-panel {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.field-row {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.field-row label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.field-row input {
+  width: min(100%, 24rem);
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 0.5rem;
+  color: #e5e7eb;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.session-status {
+  margin: 0 0 1rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.65rem;
+  font-weight: 700;
+  color: #dbeafe;
+  background: rgba(30, 64, 175, 0.28);
+}

--- a/app/app.js
+++ b/app/app.js
@@ -1,119 +1,293 @@
-const contracts = {
-  me: {
-    endpoint: "GET /api/me",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      userId: "demo-user-001",
-      displayName: "Phase 2 Demo User",
-      activeSystemId: "demo-system-001"
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  system: {
-    endpoint: "GET /api/systems/current",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      systemId: "demo-system-001",
-      displayName: "Phase 2 Demo System",
-      totalCount: 1
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  members: {
-    endpoint: "GET /api/members",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      totalCount: 49,
-      sampleItems: [
-        { memberId: "demo-member-001", displayName: "Demo Member 001" },
-        { memberId: "demo-member-002", displayName: "Demo Member 002" },
-        { memberId: "demo-member-003", displayName: "Demo Member 003" }
-      ]
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  frontHistory: {
-    endpoint: "GET /api/front-history",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      totalCount: 886,
-      sampleItems: [
-        { frontHistoryId: "demo-front-001", memberId: "demo-member-001", startedAtUtc: "2026-01-01T00:00:00Z" },
-        { frontHistoryId: "demo-front-002", memberId: "demo-member-002", startedAtUtc: "2026-01-02T00:00:00Z" }
-      ]
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  privacyBuckets: {
-    endpoint: "GET /api/privacy-buckets",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      totalCount: 2,
-      sampleItems: [
-        { privacyBucketId: "demo-privacy-001", label: "Demo Public" },
-        { privacyBucketId: "demo-privacy-002", label: "Demo Trusted" }
-      ]
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  customFields: {
-    endpoint: "GET /api/custom-fields",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      totalCount: 7,
-      sampleItems: [
-        { customFieldId: "demo-field-001", fieldName: "Demo Field 001" },
-        { customFieldId: "demo-field-002", fieldName: "Demo Field 002" }
-      ]
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  },
-  importMetadata: {
-    endpoint: "GET /api/imports/current",
-    contractVersion: "phase-2-readonly-surface",
-    data: {
-      sourceSystems: 1,
-      importBatches: 1,
-      sourceRecords: 945,
-      sourceIdMap: 945
-    },
-    safety: {
-      canWrite: false,
-      usesPrivateData: false
-    }
-  }
+const contractVersion = "phase-3-login-contract";
+
+const mockSession = {
+  isAuthenticated: false,
+  user: null,
+  selectedSystemId: null
 };
 
-const output = document.getElementById("appOutput");
-const buttons = document.querySelectorAll("[data-contract]");
+const demoUser = {
+  userId: "mock-user-001",
+  username: "demo.user",
+  displayName: "Demo User",
+  authenticationProvider: "PluralBridge planned username/password contract"
+};
 
-function renderContract(key) {
-  output.textContent = JSON.stringify(contracts[key], null, 2);
-  buttons.forEach((button) => {
-    button.setAttribute("aria-pressed", String(button.dataset.contract === key));
+const demoSystemAuthorization = {
+  userId: "mock-user-001",
+  authorizedSystems: [
+    {
+      systemId: "mock-system-001",
+      systemName: "Demo System",
+      role: "owner",
+      canRead: true,
+      canWrite: false,
+      selected: true
+    }
+  ]
+};
+
+function baseEnvelope(endpoint, method) {
+  return {
+    contractVersion: contractVersion,
+    endpoint: endpoint,
+    method: method,
+    transport: "planned REST API",
+    mockOnly: true,
+    canWrite: false,
+    usesPrivateData: false
+  };
+}
+
+function currentSessionSummary() {
+  return {
+    isAuthenticated: mockSession.isAuthenticated,
+    user: mockSession.user,
+    selectedSystemId: mockSession.selectedSystemId
+  };
+}
+
+function loginSuccess(username) {
+  mockSession.isAuthenticated = true;
+  mockSession.user = Object.assign({}, demoUser, {
+    username: username || demoUser.username
+  });
+  mockSession.selectedSystemId = "mock-system-001";
+
+  return Object.assign({}, baseEnvelope("/api/session/login", "POST"), {
+    result: "authenticated",
+    session: currentSessionSummary(),
+    userToSystemMapping: demoSystemAuthorization,
+    note: "Authentication creates a user session first. System access is supplied by explicit authorization mapping."
   });
 }
 
-buttons.forEach((button) => {
-  button.addEventListener("click", () => renderContract(button.dataset.contract));
+function loginFailure() {
+  mockSession.isAuthenticated = false;
+  mockSession.user = null;
+  mockSession.selectedSystemId = null;
+
+  return Object.assign({}, baseEnvelope("/api/session/login", "POST"), {
+    result: "rejected",
+    errorCode: "INVALID_CREDENTIALS",
+    session: currentSessionSummary(),
+    userToSystemMapping: {
+      userId: null,
+      authorizedSystems: []
+    },
+    note: "Failed authentication yields no user identity and no System authorization."
+  });
+}
+
+function logout() {
+  mockSession.isAuthenticated = false;
+  mockSession.user = null;
+  mockSession.selectedSystemId = null;
+
+  return Object.assign({}, baseEnvelope("/api/session/logout", "POST"), {
+    result: "signed out",
+    session: currentSessionSummary(),
+    userToSystemMapping: {
+      userId: null,
+      authorizedSystems: []
+    }
+  });
+}
+
+function sessionContract() {
+  return Object.assign({}, baseEnvelope("/api/session", "GET"), {
+    session: currentSessionSummary(),
+    note: "Session state reports authentication only. It does not imply access to any System."
+  });
+}
+
+function systemMappingContract() {
+  return Object.assign({}, baseEnvelope("/api/session/systems", "GET"), {
+    session: currentSessionSummary(),
+    userToSystemMapping: mockSession.isAuthenticated ? demoSystemAuthorization : {
+      userId: null,
+      authorizedSystems: []
+    },
+    note: "The authenticated user and authorized System are separate contract objects."
+  });
+}
+
+const contracts = {
+  me: Object.assign({}, baseEnvelope("/api/me", "GET"), {
+    authRequired: true,
+    session: currentSessionSummary(),
+    response: {
+      userId: "mock-user-001",
+      username: "demo.user",
+      displayName: "Demo User",
+      selectedSystemId: "mock-system-001"
+    }
+  }),
+  system: Object.assign({}, baseEnvelope("/api/systems/{systemId}", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      systemId: "mock-system-001",
+      displayName: "Demo System",
+      sourceSystem: "APPARYLLIS",
+      importedSystemCount: 1
+    }
+  }),
+  members: Object.assign({}, baseEnvelope("/api/systems/{systemId}/members", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      count: 49,
+      items: [
+        {
+          memberId: "mock-member-001",
+          displayName: "Member 001",
+          privacyBucket: "public"
+        }
+      ]
+    }
+  }),
+  frontHistory: Object.assign({}, baseEnvelope("/api/systems/{systemId}/front-history", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      count: 886,
+      items: [
+        {
+          frontHistoryId: "mock-front-history-001",
+          memberId: "mock-member-001",
+          startedAtUtc: "2026-01-01T00:00:00Z",
+          endedAtUtc: "2026-01-01T01:00:00Z"
+        }
+      ]
+    }
+  }),
+  privacyBuckets: Object.assign({}, baseEnvelope("/api/systems/{systemId}/privacy-buckets", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      count: 2,
+      items: [
+        {
+          privacyBucketId: "mock-privacy-bucket-public",
+          name: "public"
+        },
+        {
+          privacyBucketId: "mock-privacy-bucket-private",
+          name: "private"
+        }
+      ]
+    }
+  }),
+  customFields: Object.assign({}, baseEnvelope("/api/systems/{systemId}/custom-fields", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      count: 7,
+      items: [
+        {
+          customFieldId: "mock-custom-field-001",
+          name: "example field",
+          fieldType: "text"
+        }
+      ]
+    }
+  }),
+  importMetadata: Object.assign({}, baseEnvelope("/api/systems/{systemId}/import-metadata", "GET"), {
+    authRequired: true,
+    systemAuthorizationRequired: true,
+    response: {
+      importBatchCount: 1,
+      sourceRecordCount: 945,
+      sourceIdMapCount: 945,
+      sourceSystemCount: 1
+    }
+  })
+};
+
+const output = document.getElementById("appOutput");
+const contractButtons = document.querySelectorAll("[data-contract]");
+const sessionButtons = document.querySelectorAll("[data-session-action]");
+const loginForm = document.getElementById("loginForm");
+const usernameInput = document.getElementById("username");
+const sessionStatus = document.getElementById("sessionStatus");
+
+function updateSessionStatus() {
+  if (mockSession.isAuthenticated) {
+    sessionStatus.textContent = "Session: signed in as " + mockSession.user.username + ", selected System " + mockSession.selectedSystemId;
+  } else {
+    sessionStatus.textContent = "Session: signed out";
+  }
+}
+
+function renderPayload(payload) {
+  output.textContent = JSON.stringify(payload, null, 2);
+  updateSessionStatus();
+}
+
+function renderContract(key) {
+  contractButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", String(button.dataset.contract === key));
+  });
+  sessionButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", "false");
+  });
+  renderPayload(Object.assign({}, contracts[key], {
+    session: currentSessionSummary(),
+    userToSystemMapping: systemMappingContract().userToSystemMapping
+  }));
+}
+
+function renderSessionAction(action) {
+  contractButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", "false");
+  });
+  sessionButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", String(button.dataset.sessionAction === action));
+  });
+
+  if (action === "login") {
+    renderPayload(loginSuccess(usernameInput.value.trim()));
+    return;
+  }
+
+  if (action === "loginFailure") {
+    renderPayload(loginFailure());
+    return;
+  }
+
+  if (action === "session") {
+    renderPayload(sessionContract());
+    return;
+  }
+
+  if (action === "systemMapping") {
+    renderPayload(systemMappingContract());
+    return;
+  }
+
+  if (action === "logout") {
+    renderPayload(logout());
+  }
+}
+
+loginForm.addEventListener("submit", function(event) {
+  event.preventDefault();
+  renderSessionAction("login");
 });
 
-renderContract("me");
+sessionButtons.forEach(function(button) {
+  if (button.dataset.sessionAction !== "login") {
+    button.addEventListener("click", function() {
+      renderSessionAction(button.dataset.sessionAction);
+    });
+  }
+});
+
+contractButtons.forEach(function(button) {
+  button.addEventListener("click", function() {
+    renderContract(button.dataset.contract);
+  });
+});
+
+updateSessionStatus();

--- a/app/index.html
+++ b/app/index.html
@@ -3,15 +3,37 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>PluralBridge App</title>
+  <title>PluralBridge App Proof</title>
   <link rel="stylesheet" href="./app.css">
 </head>
 <body>
   <main class="app-shell" aria-labelledby="app-title">
     <section class="app-card">
       <p class="eyebrow">PluralBridge application proof</p>
-      <h1 id="app-title">Phase 2: read-only data surface contract</h1>
-      <p>Static planned-contract responses for the validated 1-6 slice. No login, no API connection, no private data, no write path.</p>
+      <h1 id="app-title">Phase 3: login and session contract</h1>
+      <p>Static planned-contract responses for login, logout, session state, authorized System mapping, and the validated 1-6 read-only slice.</p>
+      <p>No API connection, no Azure connection, no private data, and no write path beyond local mock session state.</p>
+
+      <form id="loginForm" class="login-panel">
+        <div class="field-row">
+          <label for="username">Username</label>
+          <input id="username" name="username" autocomplete="username" value="demo.user">
+        </div>
+        <div class="field-row">
+          <label for="password">Password</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" value="pluralbridge-demo">
+        </div>
+        <div class="button-row" aria-label="Session contract actions">
+          <button type="submit" data-session-action="login">login</button>
+          <button type="button" data-session-action="loginFailure">login failure</button>
+          <button type="button" data-session-action="session">session</button>
+          <button type="button" data-session-action="systemMapping">system mapping</button>
+          <button type="button" data-session-action="logout">logout</button>
+        </div>
+      </form>
+
+      <div id="sessionStatus" class="session-status">Session: signed out</div>
+
       <div class="button-row" aria-label="Read-only contract actions">
         <button type="button" data-contract="me">me</button>
         <button type="button" data-contract="system">system</button>
@@ -21,9 +43,11 @@
         <button type="button" data-contract="customFields">custom fields</button>
         <button type="button" data-contract="importMetadata">import metadata</button>
       </div>
+
       <pre id="appOutput" class="output-box" aria-live="polite">{ }</pre>
     </section>
   </main>
+
   <script src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the Phase 3 browser-only login/session contract proof under app/.

Scope:
- Adds username/password login surface.
- Adds mock login success, login failure, session, system mapping, and logout contracts.
- Preserves the Phase 2 read-only 1-6 surface buttons.
- Keeps authenticated user identity separate from authorized/selected System mapping.
- Uses static/mock planned-contract JSON only.

Out of scope:
- No real API connection.
- No Azure connection.
- No private data.
- No server implementation.
- No write path beyond local mock session state.