### PR TITLE
Release v0.7.0 Phase 2B read-only API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ database/targeting/prop_candidate/cloud/*.log
 database/targeting/prop_candidate/cloud/*.local.txt
 database/targeting/prop_candidate/cloud/**/*.json
 database/targeting/prop_candidate/cloud/**/*.jsonl
+
+# Visual Studio / .NET build output
+.vs/
+**/bin/
+**/obj/
+*.user

--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -6,6 +6,30 @@ Tags are listed in reverse chronological order so the latest project changes app
 
 ---
 
+## v0.7.0 — Read-only C# API and database-backed browser proof
+
+### Major tasks completed
+
+- Added the first durable ASP.NET Core C# REST API under `api/`.
+- Added Microsoft.Data.SqlClient database access against the validated Azure SQL proof database.
+- Added read-only REST endpoints for `me`, source systems, import batches, systems, members, privacy buckets, custom fields, front history, source records, source ID mappings, and import metadata.
+- Wired the browser app read-only buttons to real API calls instead of static mock contract payloads.
+- Preserved the Phase 3A login/session surface as frozen placeholder behavior while completing Phase 2B.
+- Confirmed all required Phase 2B browser/API counts from the validated 1-6 proof slice: 1 source system, 1 import batch, 1 system, 49 members, 2 privacy buckets, 7 custom fields, 886 front-history rows, 945 source records, and 945 source ID mappings.
+- Kept all Phase 2B endpoints read-only with `canWrite` set to false.
+- Excluded raw source JSON from the public source-record endpoint while preserving source inventory and hash metadata.
+- Added Visual Studio and .NET ignore rules so local build output, user settings, and transient IDE files stay out of repository history.
+- Added output-box CSS wrapping and height limits so large JSON payloads remain usable in the browser proof surface.
+
+### Notes
+
+This release marks the first PluralBridge browser proof backed by a durable C# REST API and real Azure SQL data. It corrects the Phase 2 read-only surface so the app now proves live database retrieval across the complete 1-6 proof slice instead of static browser-side contract JSON.
+
+The API still uses a fixed Phase 2B proof context. Phase 3 remains responsible for replacing that fixed context with real login, session, and user-to-System mapping behavior.
+
+
+---
+
 ## v0.6.0 — Azure SQL cloud-readiness proof
 
 ### Major tasks completed

--- a/api/PluralBridge.Api/PluralBridge.Api.sln
+++ b/api/PluralBridge.Api/PluralBridge.Api.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37314.3 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralBridge.Api", "PluralBridge.Api\PluralBridge.Api.csproj", "{D40E659B-E483-405D-BD49-1EE1EBDE890C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D40E659B-E483-405D-BD49-1EE1EBDE890C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D40E659B-E483-405D-BD49-1EE1EBDE890C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D40E659B-E483-405D-BD49-1EE1EBDE890C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D40E659B-E483-405D-BD49-1EE1EBDE890C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BF5C65E4-340D-4E25-AC7D-DA2AA63CC3CC}
+	EndGlobalSection
+EndGlobal

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/CustomFieldsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/CustomFieldsController.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only custom fields endpoint for the Phase 2B proof surface.
+/// Custom fields are returned for a specific imported PluralBridge system.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/custom-fields")]
+public sealed class CustomFieldsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all custom fields for the requested system from the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the custom field query.</param>
+	/// <returns>
+	/// HTTP 200 with custom field rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var customFields = await ReadCustomFieldsAsync(connection, systemId);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/custom-fields",
+			canWrite = false,
+			systemId,
+			count = customFields.Count,
+			customFields
+		});
+	}
+
+	/// <summary>
+	/// Reads custom field rows for one system from the validated proof database.
+	/// The selected fields expose imported custom-field metadata without exposing raw source payloads.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the custom field query.</param>
+	/// <returns>The custom field rows ordered by display order, field name, and custom field identifier.</returns>
+	private static async Task<List<CustomField>> ReadCustomFieldsAsync(SqlConnection connection, Guid systemId)
+	{
+		const string sql = """
+		                   SELECT
+		                       CustomFieldId,
+		                       SystemId,
+		                       FieldName,
+		                       Description,
+		                       FieldTypeCode,
+		                       DisplayOrderText,
+		                       SupportsMarkdown,
+		                       ImportedAtUtc,
+		                       CreatedAtUtc,
+		                       UpdatedAtUtc
+		                   FROM dbo.pb_custom_fields
+		                   WHERE SystemId = @SystemId
+		                   ORDER BY DisplayOrderText, FieldName, CustomFieldId;
+		                   """;
+
+		var customFields = new List<CustomField>();
+
+		await using var command = new SqlCommand(sql, connection);
+		command.Parameters.AddWithValue("@SystemId", systemId);
+
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			customFields.Add(new CustomField(
+				reader.GetGuid(0),
+				reader.GetGuid(1),
+				reader.GetString(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.IsDBNull(4) ? null : reader.GetInt32(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetBoolean(6),
+				reader.GetDateTime(7),
+				reader.GetDateTime(8),
+				reader.IsDBNull(9) ? null : reader.GetDateTime(9)));
+		}
+
+		return customFields;
+	}
+
+	private sealed record CustomField(
+		Guid CustomFieldId,
+		Guid SystemId,
+		string FieldName,
+		string? Description,
+		int? FieldTypeCode,
+		string? DisplayOrderText,
+		bool? SupportsMarkdown,
+		DateTime ImportedAtUtc,
+		DateTime CreatedAtUtc,
+		DateTime? UpdatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/FrontHistoryController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/FrontHistoryController.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only front history endpoint for the Phase 2B proof surface.
+/// Front history rows are returned for a specific imported PluralBridge system.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/front-history")]
+public sealed class FrontHistoryController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all front history rows for the requested system from the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the front history query.</param>
+	/// <returns>
+	/// HTTP 200 with front history rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var frontHistory = await ReadFrontHistoryAsync(connection, systemId);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/front-history",
+			canWrite = false,
+			systemId,
+			count = frontHistory.Count,
+			frontHistory
+		});
+	}
+
+	/// <summary>
+	/// Reads front history rows for one system from the validated proof database.
+	/// The selected fields expose imported fronting timeline data and include member display names for browser readability.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the front history query.</param>
+	/// <returns>The front history rows ordered by start time and front history identifier.</returns>
+	private static async Task<List<FrontHistoryRecord>> ReadFrontHistoryAsync(SqlConnection connection, Guid systemId)
+	{
+		const string sql = """
+		                   SELECT
+		                       fh.FrontHistoryId,
+		                       fh.SystemId,
+		                       fh.MemberId,
+		                       m.DisplayName,
+		                       fh.StartTimeMs,
+		                       fh.EndTimeMs,
+		                       fh.IsLive,
+		                       fh.IsCustom,
+		                       fh.CustomStatus,
+		                       fh.LastOperationTimeMs,
+		                       fh.ImportedAtUtc,
+		                       fh.CreatedAtUtc,
+		                       fh.UpdatedAtUtc
+		                   FROM dbo.pb_front_history AS fh
+		                   LEFT JOIN dbo.pb_members AS m
+		                       ON m.MemberId = fh.MemberId
+		                   WHERE fh.SystemId = @SystemId
+		                   ORDER BY fh.StartTimeMs, fh.FrontHistoryId;
+		                   """;
+
+		var frontHistory = new List<FrontHistoryRecord>();
+
+		await using var command = new SqlCommand(sql, connection);
+		command.Parameters.AddWithValue("@SystemId", systemId);
+
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			frontHistory.Add(new FrontHistoryRecord(
+				reader.GetGuid(0),
+				reader.GetGuid(1),
+				reader.GetGuid(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.GetInt64(4),
+				reader.IsDBNull(5) ? null : reader.GetInt64(5),
+				reader.IsDBNull(6) ? null : reader.GetBoolean(6),
+				reader.IsDBNull(7) ? null : reader.GetBoolean(7),
+				reader.IsDBNull(8) ? null : reader.GetString(8),
+				reader.IsDBNull(9) ? null : reader.GetInt64(9),
+				reader.GetDateTime(10),
+				reader.GetDateTime(11),
+				reader.IsDBNull(12) ? null : reader.GetDateTime(12)));
+		}
+
+		return frontHistory;
+	}
+
+	private sealed record FrontHistoryRecord(
+		Guid FrontHistoryId,
+		Guid SystemId,
+		Guid MemberId,
+		string? MemberDisplayName,
+		long StartTimeMs,
+		long? EndTimeMs,
+		bool? IsLive,
+		bool? IsCustom,
+		string? CustomStatus,
+		long? LastOperationTimeMs,
+		DateTime ImportedAtUtc,
+		DateTime CreatedAtUtc,
+		DateTime? UpdatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/ImportBatchesController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/ImportBatchesController.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only import batches endpoint for the Phase 2B proof surface.
+/// Import batches describe when source data was imported and which source system produced it.
+/// </summary>
+[ApiController]
+[Route("api/import-batches")]
+public sealed class ImportBatchesController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all import batches present in the validated proof database.
+	/// The response includes count metadata and excludes raw source payloads.
+	/// </summary>
+	/// <returns>
+	/// HTTP 200 with import batch rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get()
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var importBatches = await ReadImportBatchesAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = "/api/import-batches",
+			canWrite = false,
+			count = importBatches.Count,
+			importBatches
+		});
+	}
+
+	/// <summary>
+	/// Reads import batch rows from the validated proof database.
+	/// The selected fields expose operational import metadata without returning private source JSON.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The import batch rows ordered by import start time and batch identifier.</returns>
+	private static async Task<List<ImportBatch>> ReadImportBatchesAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT
+		                       ImportBatchId,
+		                       SourceSystemCode,
+		                       ImportStartedAtUtc,
+		                       ImportCompletedAtUtc,
+		                       ImportToolName,
+		                       ImportToolVersion,
+		                       SourceExportName,
+		                       SourceExportSha256,
+		                       CreatedAtUtc
+		                   FROM dbo.pb_import_batches
+		                   ORDER BY ImportStartedAtUtc, ImportBatchId;
+		                   """;
+
+		var importBatches = new List<ImportBatch>();
+
+		await using var command = new SqlCommand(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			importBatches.Add(new ImportBatch(
+				reader.GetGuid(0),
+				reader.GetString(1),
+				reader.GetDateTime(2),
+				reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetString(6),
+				reader.IsDBNull(7) ? null : Convert.ToHexString((byte[])reader[7]),
+				reader.GetDateTime(8)));
+		}
+
+		return importBatches;
+	}
+
+	private sealed record ImportBatch(
+		Guid ImportBatchId,
+		string SourceSystemCode,
+		DateTime ImportStartedAtUtc,
+		DateTime? ImportCompletedAtUtc,
+		string? ImportToolName,
+		string? ImportToolVersion,
+		string? SourceExportName,
+		string? SourceExportSha256Hex,
+		DateTime CreatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/ImportMetadataController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/ImportMetadataController.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only import metadata endpoint for the Phase 2B proof surface.
+/// Import metadata summarizes source-system, batch, source-record, and source-ID mapping state for the proof route.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/import-metadata")]
+public sealed class ImportMetadataController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns import metadata for the requested proof system route.
+	/// The response summarizes import counts and latest batch metadata without exposing raw source payloads.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the proof route.</param>
+	/// <returns>
+	/// HTTP 200 with import metadata, aggregate counts, latest batch information, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var importMetadata = await ReadImportMetadataAsync(connection, systemId);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/import-metadata",
+			canWrite = false,
+			systemId,
+			importMetadata
+		});
+	}
+
+	/// <summary>
+	/// Reads aggregate import metadata from the validated proof database.
+	/// The selected values give the browser a compact view of the import surface without returning private source JSON.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <param name="systemId">The PluralBridge system identifier used to confirm the proof system route.</param>
+	/// <returns>Aggregate import metadata and latest import batch details.</returns>
+	private static async Task<ImportMetadata> ReadImportMetadataAsync(SqlConnection connection, Guid systemId)
+	{
+		const string sql = """
+		                   SELECT
+		                       SystemExists = CAST(CASE WHEN EXISTS
+		                       (
+		                           SELECT 1
+		                           FROM dbo.pb_systems
+		                           WHERE SystemId = @SystemId
+		                       )
+		                       THEN 1 ELSE 0 END AS bit),
+		                       SourceSystemCount = CAST((SELECT COUNT_BIG(*) FROM dbo.pb_source_systems) AS bigint),
+		                       ImportBatchCount = CAST((SELECT COUNT_BIG(*) FROM dbo.pb_import_batches) AS bigint),
+		                       SourceRecordCount = CAST((SELECT COUNT_BIG(*) FROM dbo.pb_source_records) AS bigint),
+		                       SourceIdMappingCount = CAST((SELECT COUNT_BIG(*) FROM dbo.pb_source_id_map) AS bigint);
+
+		                   SELECT TOP (1)
+		                       ImportBatchId,
+		                       SourceSystemCode,
+		                       ImportStartedAtUtc,
+		                       ImportCompletedAtUtc,
+		                       ImportToolName,
+		                       ImportToolVersion,
+		                       SourceExportName,
+		                       CreatedAtUtc
+		                   FROM dbo.pb_import_batches
+		                   ORDER BY ImportStartedAtUtc DESC, ImportBatchId;
+		                   """;
+
+		await using var command = new SqlCommand(sql, connection);
+		command.Parameters.AddWithValue("@SystemId", systemId);
+
+		await using var reader = await command.ExecuteReaderAsync();
+
+		await reader.ReadAsync();
+
+		var systemExists = reader.GetBoolean(0);
+		var sourceSystemCount = reader.GetInt64(1);
+		var importBatchCount = reader.GetInt64(2);
+		var sourceRecordCount = reader.GetInt64(3);
+		var sourceIdMappingCount = reader.GetInt64(4);
+
+		LatestImportBatch? latestImportBatch = null;
+
+		await reader.NextResultAsync();
+
+		if (await reader.ReadAsync())
+		{
+			latestImportBatch = new LatestImportBatch(
+				reader.GetGuid(0),
+				reader.GetString(1),
+				reader.GetDateTime(2),
+				reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetString(6),
+				reader.GetDateTime(7));
+		}
+
+		return new ImportMetadata(
+			systemExists,
+			sourceSystemCount,
+			importBatchCount,
+			sourceRecordCount,
+			sourceIdMappingCount,
+			latestImportBatch);
+	}
+
+	private sealed record ImportMetadata(
+		bool SystemExists,
+		long SourceSystemCount,
+		long ImportBatchCount,
+		long SourceRecordCount,
+		long SourceIdMappingCount,
+		LatestImportBatch? LatestImportBatch);
+
+	private sealed record LatestImportBatch(
+		Guid ImportBatchId,
+		string SourceSystemCode,
+		DateTime ImportStartedAtUtc,
+		DateTime? ImportCompletedAtUtc,
+		string? ImportToolName,
+		string? ImportToolVersion,
+		string? SourceExportName,
+		DateTime CreatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/MeController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/MeController.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the Phase 2B read-only proof endpoint for the current proof context.
+/// This controller verifies that the API can reach the validated PluralBridge cloud proof database
+/// and returns the system identifier plus table counts needed by the browser proof surface.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public sealed class MeController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns the current Phase 2B proof context.
+	/// The response is intentionally read-only and includes the proof system plus validated table counts
+	/// so the browser can confirm that it is receiving real database-backed data.
+	/// </summary>
+	/// <returns>
+	/// HTTP 200 with proof metadata, the selected proof system, write capability set to false,
+	/// and counts for the Phase 2B source and 1-6 slice tables.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get()
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using SqlConnection connection = new(connectionString);
+		await connection.OpenAsync();
+
+		var counts = await ReadCountsAsync(connection);
+		var proofSystem = await ReadProofSystemAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			mode = "read-only proof",
+			database = "PluralBridgeCloudProof001",
+			canWrite = false,
+			proofSystem,
+			counts
+		});
+	}
+
+	/// <summary>
+	/// Reads count totals from the source and 1-6 proof tables in the validated database.
+	/// These totals are used as a compact integrity check for the Phase 2B browser proof.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>A dictionary keyed by API-facing count names.</returns>
+	private static async Task<Dictionary<string, long>> ReadCountsAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_source_systems;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_import_batches;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_systems;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_members;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_privacy_buckets;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_custom_fields;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_front_history;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_source_records;
+		                   SELECT CAST(COUNT_BIG(*) AS bigint) FROM dbo.pb_source_id_map;
+		                   """;
+
+		string[] names =
+		[
+			"sourceSystems",
+			"importBatches",
+			"systems",
+			"members",
+			"privacyBuckets",
+			"customFields",
+			"frontHistory",
+			"sourceRecords",
+			"sourceIdMappings"
+		];
+
+		Dictionary<string, long> counts = new();
+
+		await using SqlCommand command = new(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		for (var index = 0; index < names.Length; index++)
+		{
+			if (await reader.ReadAsync())
+			{
+				counts[names[index]] = reader.GetInt64(0);
+			}
+
+			if (index < names.Length - 1)
+			{
+				await reader.NextResultAsync();
+			}
+		}
+
+		return counts;
+	}
+
+	/// <summary>
+	/// Reads the first proof system from the validated database.
+	/// Phase 2B uses this fixed proof context until Phase 3 replaces it with login/session mapping.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The selected proof system, or null when the proof database has no system row.</returns>
+	private static async Task<ProofSystem?> ReadProofSystemAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT TOP (1)
+		                       SystemId,
+		                       SystemName
+		                   FROM dbo.pb_systems
+		                   ORDER BY CreatedAtUtc, SystemId;
+		                   """;
+
+		await using SqlCommand command = new(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		if (!await reader.ReadAsync())
+		{
+			return null;
+		}
+
+		return new ProofSystem(
+			reader.GetGuid(0),
+			reader.IsDBNull(1) ? null : reader.GetString(1));
+	}
+
+	private sealed record ProofSystem(Guid SystemId, string? SystemName);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/MembersController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/MembersController.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only members endpoint for the Phase 2B proof surface.
+/// Members are returned for a specific imported PluralBridge system.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/members")]
+public sealed class MembersController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all members for the requested system from the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the member query.</param>
+	/// <returns>
+	/// HTTP 200 with member rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var members = await ReadMembersAsync(connection, systemId);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/members",
+			canWrite = false,
+			systemId,
+			count = members.Count,
+			members
+		});
+	}
+
+	/// <summary>
+	/// Reads member rows for one system from the validated proof database.
+	/// The selected fields expose imported member metadata without exposing raw source payloads.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the member query.</param>
+	/// <returns>The member rows ordered by display name and member identifier.</returns>
+	private static async Task<List<Member>> ReadMembersAsync(SqlConnection connection, Guid systemId)
+	{
+		const string sql = """
+		                   SELECT
+		                       MemberId,
+		                       SystemId,
+		                       DisplayName,
+		                       Pronouns,
+		                       Description,
+		                       Color,
+		                       IsArchived,
+		                       ArchivedReason,
+		                       IsPrivate,
+		                       PreventTrusted,
+		                       PreventsFrontNotifications,
+		                       ReceiveMessageBoardNotifications,
+		                       SupportsDescriptionMarkdown,
+		                       LastOperationTimeMs,
+		                       ImportedAtUtc,
+		                       CreatedAtUtc,
+		                       UpdatedAtUtc
+		                   FROM dbo.pb_members
+		                   WHERE SystemId = @SystemId
+		                   ORDER BY DisplayName, MemberId;
+		                   """;
+
+		var members = new List<Member>();
+
+		await using var command = new SqlCommand(sql, connection);
+		command.Parameters.AddWithValue("@SystemId", systemId);
+
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			members.Add(new Member(
+				reader.GetGuid(0),
+				reader.GetGuid(1),
+				reader.GetString(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetBoolean(6),
+				reader.IsDBNull(7) ? null : reader.GetString(7),
+				reader.IsDBNull(8) ? null : reader.GetBoolean(8),
+				reader.IsDBNull(9) ? null : reader.GetBoolean(9),
+				reader.IsDBNull(10) ? null : reader.GetBoolean(10),
+				reader.IsDBNull(11) ? null : reader.GetBoolean(11),
+				reader.IsDBNull(12) ? null : reader.GetBoolean(12),
+				reader.IsDBNull(13) ? null : reader.GetInt64(13),
+				reader.GetDateTime(14),
+				reader.GetDateTime(15),
+				reader.IsDBNull(16) ? null : reader.GetDateTime(16)));
+		}
+
+		return members;
+	}
+
+	private sealed record Member(
+		Guid MemberId,
+		Guid SystemId,
+		string DisplayName,
+		string? Pronouns,
+		string? Description,
+		string? Color,
+		bool? IsArchived,
+		string? ArchivedReason,
+		bool? IsPrivate,
+		bool? PreventTrusted,
+		bool? PreventsFrontNotifications,
+		bool? ReceiveMessageBoardNotifications,
+		bool? SupportsDescriptionMarkdown,
+		long? LastOperationTimeMs,
+		DateTime ImportedAtUtc,
+		DateTime CreatedAtUtc,
+		DateTime? UpdatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/PrivacyBucketsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/PrivacyBucketsController.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only privacy buckets endpoint for the Phase 2B proof surface.
+/// Privacy buckets are returned for a specific imported PluralBridge system.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/privacy-buckets")]
+public sealed class PrivacyBucketsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all privacy buckets for the requested system from the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the privacy bucket query.</param>
+	/// <returns>
+	/// HTTP 200 with privacy bucket rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var privacyBuckets = await ReadPrivacyBucketsAsync(connection, systemId);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/privacy-buckets",
+			canWrite = false,
+			systemId,
+			count = privacyBuckets.Count,
+			privacyBuckets
+		});
+	}
+
+	/// <summary>
+	/// Reads privacy bucket rows for one system from the validated proof database.
+	/// The selected fields expose imported privacy grouping metadata without exposing raw source payloads.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the privacy bucket query.</param>
+	/// <returns>The privacy bucket rows ordered by rank text, bucket name, and bucket identifier.</returns>
+	private static async Task<List<PrivacyBucket>> ReadPrivacyBucketsAsync(SqlConnection connection, Guid systemId)
+	{
+		const string sql = """
+		                   SELECT
+		                       PrivacyBucketId,
+		                       SystemId,
+		                       BucketName,
+		                       Description,
+		                       Color,
+		                       Icon,
+		                       RankText,
+		                       ImportedAtUtc,
+		                       CreatedAtUtc,
+		                       UpdatedAtUtc
+		                   FROM dbo.pb_privacy_buckets
+		                   WHERE SystemId = @SystemId
+		                   ORDER BY RankText, BucketName, PrivacyBucketId;
+		                   """;
+
+		var privacyBuckets = new List<PrivacyBucket>();
+
+		await using var command = new SqlCommand(sql, connection);
+		command.Parameters.AddWithValue("@SystemId", systemId);
+
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			privacyBuckets.Add(new PrivacyBucket(
+				reader.GetGuid(0),
+				reader.GetGuid(1),
+				reader.GetString(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetString(6),
+				reader.GetDateTime(7),
+				reader.GetDateTime(8),
+				reader.IsDBNull(9) ? null : reader.GetDateTime(9)));
+		}
+
+		return privacyBuckets;
+	}
+
+	private sealed record PrivacyBucket(
+		Guid PrivacyBucketId,
+		Guid SystemId,
+		string BucketName,
+		string? Description,
+		string? Color,
+		string? Icon,
+		string? RankText,
+		DateTime ImportedAtUtc,
+		DateTime CreatedAtUtc,
+		DateTime? UpdatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceIdMappingsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceIdMappingsController.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only source ID mappings endpoint for the Phase 2B proof surface.
+/// Source ID mappings connect external source identifiers to PluralBridge entity identifiers.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/source-id-mappings")]
+public sealed class SourceIdMappingsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns source ID mapping rows for the requested proof system route.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the proof route.</param>
+	/// <returns>
+	/// HTTP 200 with source ID mapping rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var sourceIdMappings = await ReadSourceIdMappingsAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/source-id-mappings",
+			canWrite = false,
+			systemId,
+			count = sourceIdMappings.Count,
+			sourceIdMappings
+		});
+	}
+
+	/// <summary>
+	/// Reads source ID mapping rows from the validated proof database.
+	/// These rows provide traceability from source-system identifiers to PluralBridge identifiers.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The source ID mapping rows ordered by source entity type, source identifier, and mapping identifier.</returns>
+	private static async Task<List<SourceIdMapping>> ReadSourceIdMappingsAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT
+		                       SourceIdMapId,
+		                       SourceSystemCode,
+		                       SourceEntityTypeCode,
+		                       SourceId,
+		                       PluralBridgeEntityTypeCode,
+		                       PluralBridgeId,
+		                       ImportBatchId,
+		                       CreatedAtUtc
+		                   FROM dbo.pb_source_id_map
+		                   ORDER BY SourceEntityTypeCode, SourceId, SourceIdMapId;
+		                   """;
+
+		var sourceIdMappings = new List<SourceIdMapping>();
+
+		await using var command = new SqlCommand(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			sourceIdMappings.Add(new SourceIdMapping(
+				reader.GetGuid(0),
+				reader.GetString(1),
+				reader.GetString(2),
+				reader.GetString(3),
+				reader.GetString(4),
+				reader.GetGuid(5),
+				reader.GetGuid(6),
+				reader.GetDateTime(7)));
+		}
+
+		return sourceIdMappings;
+	}
+
+	private sealed record SourceIdMapping(
+		Guid SourceIdMapId,
+		string SourceSystemCode,
+		string SourceEntityTypeCode,
+		string SourceId,
+		string PluralBridgeEntityTypeCode,
+		Guid PluralBridgeId,
+		Guid ImportBatchId,
+		DateTime CreatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceRecordsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceRecordsController.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only source records endpoint for the Phase 2B proof surface.
+/// Source records are returned as inventory metadata for a specific proof system route.
+/// </summary>
+[ApiController]
+[Route("api/systems/{systemId:guid}/source-records")]
+public sealed class SourceRecordsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns source record inventory rows for the requested proof system route.
+	/// The response includes count metadata and excludes raw imported JSON payloads.
+	/// </summary>
+	/// <param name="systemId">The PluralBridge system identifier used to scope the proof route.</param>
+	/// <returns>
+	/// HTTP 200 with source record inventory rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get(Guid systemId)
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var sourceRecords = await ReadSourceRecordsAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = $"/api/systems/{systemId}/source-records",
+			canWrite = false,
+			systemId,
+			count = sourceRecords.Count,
+			sourceRecords
+		});
+	}
+
+	/// <summary>
+	/// Reads source record inventory rows from the validated proof database.
+	/// RawJson stays excluded so the endpoint exposes provenance and integrity metadata without private source payloads.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The source record inventory rows ordered by source entity type, source identifier, and source record identifier.</returns>
+	private static async Task<List<SourceRecord>> ReadSourceRecordsAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT
+		                       SourceRecordId,
+		                       ImportBatchId,
+		                       SourceSystemCode,
+		                       SourceEntityTypeCode,
+		                       SourceId,
+		                       SourceEndpoint,
+		                       RawJsonSha256,
+		                       ImportedAtUtc
+		                   FROM dbo.pb_source_records
+		                   ORDER BY SourceEntityTypeCode, SourceId, SourceRecordId;
+		                   """;
+
+		var sourceRecords = new List<SourceRecord>();
+
+		await using var command = new SqlCommand(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			sourceRecords.Add(new SourceRecord(
+				reader.GetGuid(0),
+				reader.GetGuid(1),
+				reader.GetString(2),
+				reader.GetString(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : Convert.ToHexString((byte[])reader[6]),
+				reader.GetDateTime(7)));
+		}
+
+		return sourceRecords;
+	}
+
+	private sealed record SourceRecord(
+		Guid SourceRecordId,
+		Guid ImportBatchId,
+		string SourceSystemCode,
+		string SourceEntityTypeCode,
+		string? SourceId,
+		string? SourceEndpoint,
+		string? RawJsonSha256Hex,
+		DateTime ImportedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceSystemsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/SourceSystemsController.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only source systems endpoint for the Phase 2B proof surface.
+/// Source systems identify the external application families represented in the import data.
+/// </summary>
+[ApiController]
+[Route("api/source-systems")]
+public sealed class SourceSystemsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all source systems present in the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <returns>
+	/// HTTP 200 with source system rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get()
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var sourceSystems = await ReadSourceSystemsAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = "/api/source-systems",
+			canWrite = false,
+			count = sourceSystems.Count,
+			sourceSystems
+		});
+	}
+
+	/// <summary>
+	/// Reads source system rows from the validated proof database.
+	/// The selected fields expose descriptive source-system metadata without exposing private import payloads.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The source system rows ordered by source system code.</returns>
+	private static async Task<List<SourceSystem>> ReadSourceSystemsAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT
+		                       SourceSystemCode,
+		                       DisplayName,
+		                       Description,
+		                       ApiBaseUrl,
+		                       CreatedAtUtc
+		                   FROM dbo.pb_source_systems
+		                   ORDER BY SourceSystemCode;
+		                   """;
+
+		var sourceSystems = new List<SourceSystem>();
+
+		await using var command = new SqlCommand(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			sourceSystems.Add(new SourceSystem(
+				reader.GetString(0),
+				reader.GetString(1),
+				reader.IsDBNull(2) ? null : reader.GetString(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.GetDateTime(4)));
+		}
+
+		return sourceSystems;
+	}
+
+	private sealed record SourceSystem(
+		string SourceSystemCode,
+		string DisplayName,
+		string? Description,
+		string? ApiBaseUrl,
+		DateTime CreatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/Controllers/SystemsController.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Controllers/SystemsController.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+namespace PluralBridge.Api.Controllers;
+
+/// <summary>
+/// Provides the read-only systems endpoint for the Phase 2B proof surface.
+/// Systems represent imported PluralBridge system records from the validated proof database.
+/// </summary>
+[ApiController]
+[Route("api/systems")]
+public sealed class SystemsController(IConfiguration configuration) : ControllerBase
+{
+	/// <summary>
+	/// Returns all systems present in the validated proof database.
+	/// The response includes count metadata and keeps write capability explicitly disabled.
+	/// </summary>
+	/// <returns>
+	/// HTTP 200 with system rows, total count, and read-only capability metadata.
+	/// </returns>
+	[HttpGet]
+	public async Task<IActionResult> Get()
+	{
+		var connectionString = configuration.GetConnectionString("PluralBridgeProof");
+
+		if (string.IsNullOrWhiteSpace(connectionString))
+		{
+			return Problem(
+				title: "Missing connection string",
+				detail: "ConnectionStrings:PluralBridgeProof was not found.",
+				statusCode: StatusCodes.Status500InternalServerError);
+		}
+
+		await using var connection = new SqlConnection(connectionString);
+		await connection.OpenAsync();
+
+		var systems = await ReadSystemsAsync(connection);
+
+		return Ok(new
+		{
+			api = "PluralBridge.Api",
+			phase = "Phase 2B",
+			endpoint = "/api/systems",
+			canWrite = false,
+			count = systems.Count,
+			systems
+		});
+	}
+
+	/// <summary>
+	/// Reads system rows from the validated proof database.
+	/// The selected fields expose imported system metadata needed by the browser proof surface.
+	/// </summary>
+	/// <param name="connection">An open SQL Server connection to the PluralBridge proof database.</param>
+	/// <returns>The system rows ordered by creation time and system identifier.</returns>
+	private static async Task<List<SystemRecord>> ReadSystemsAsync(SqlConnection connection)
+	{
+		const string sql = """
+		                   SELECT
+		                       SystemId,
+		                       SystemName,
+		                       Description,
+		                       Color,
+		                       AvatarUrl,
+		                       AvatarUuid,
+		                       SourceCreatedAtMs,
+		                       LastOperationTimeMs,
+		                       ImportedAtUtc,
+		                       CreatedAtUtc,
+		                       UpdatedAtUtc
+		                   FROM dbo.pb_systems
+		                   ORDER BY CreatedAtUtc, SystemId;
+		                   """;
+
+		var systems = new List<SystemRecord>();
+
+		await using var command = new SqlCommand(sql, connection);
+		await using var reader = await command.ExecuteReaderAsync();
+
+		while (await reader.ReadAsync())
+		{
+			systems.Add(new SystemRecord(
+				reader.GetGuid(0),
+				reader.IsDBNull(1) ? null : reader.GetString(1),
+				reader.IsDBNull(2) ? null : reader.GetString(2),
+				reader.IsDBNull(3) ? null : reader.GetString(3),
+				reader.IsDBNull(4) ? null : reader.GetString(4),
+				reader.IsDBNull(5) ? null : reader.GetString(5),
+				reader.IsDBNull(6) ? null : reader.GetInt64(6),
+				reader.IsDBNull(7) ? null : reader.GetInt64(7),
+				reader.GetDateTime(8),
+				reader.GetDateTime(9),
+				reader.IsDBNull(10) ? null : reader.GetDateTime(10)));
+		}
+
+		return systems;
+	}
+
+	private sealed record SystemRecord(
+		Guid SystemId,
+		string? SystemName,
+		string? Description,
+		string? Color,
+		string? AvatarUrl,
+		string? AvatarUuid,
+		long? SourceCreatedAtMs,
+		long? LastOperationTimeMs,
+		DateTime ImportedAtUtc,
+		DateTime CreatedAtUtc,
+		DateTime? UpdatedAtUtc);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/PluralBridge.Api.csproj
+++ b/api/PluralBridge.Api/PluralBridge.Api/PluralBridge.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>0c5e5be9-ad3c-4c2c-a7fb-5eef146bda38</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/api/PluralBridge.Api/PluralBridge.Api/PluralBridge.Api.http
+++ b/api/PluralBridge.Api/PluralBridge.Api/PluralBridge.Api.http
@@ -1,0 +1,6 @@
+@PluralBridge.Api_HostAddress = http://localhost:5148
+
+GET {{PluralBridge.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/api/PluralBridge.Api/PluralBridge.Api/Program.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Program.cs
@@ -1,0 +1,42 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddCors(options =>
+{
+	options.AddPolicy("Phase2BLocalBrowserProof", policy =>
+	{
+		policy.AllowAnyOrigin();
+		policy.AllowAnyHeader();
+		policy.AllowAnyMethod();
+	});
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+// adds middleware for HTTP -> HTTPS
+app.UseHttpsRedirection();
+
+if (app.Environment.IsDevelopment())
+{
+	// allow cross domain requests
+	app.UseCors("Phase2BLocalBrowserProof");
+}
+app.UseAuthorization();
+
+// add endpoints
+app.MapControllers();
+
+app.Run();

--- a/api/PluralBridge.Api/PluralBridge.Api/Properties/launchSettings.json
+++ b/api/PluralBridge.Api/PluralBridge.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:31642",
+      "sslPort": 44313
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5148",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7275;http://localhost:5148",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/appsettings.Development.json
+++ b/api/PluralBridge.Api/PluralBridge.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/appsettings.json
+++ b/api/PluralBridge.Api/PluralBridge.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/app/app.css
+++ b/app/app.css
@@ -79,6 +79,7 @@ button[aria-pressed="true"] {
 
 .output-box {
   min-height: 22rem;
+  max-height: 34rem;
   overflow: auto;
   margin: 0;
   padding: 1rem;
@@ -87,6 +88,8 @@ button[aria-pressed="true"] {
   background: #070a0d;
   color: #d8e1ed;
   font-size: 0.92rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .login-panel {

--- a/app/app.js
+++ b/app/app.js
@@ -1,223 +1,51 @@
-const contractVersion = "phase-3-login-contract";
+const apiBaseUrl = "https://localhost:7275";
 
-const mockSession = {
-  isAuthenticated: false,
-  user: null,
-  selectedSystemId: null
-};
-
-const demoUser = {
-  userId: "mock-user-001",
-  username: "demo.user",
-  displayName: "Demo User",
-  authenticationProvider: "PluralBridge planned username/password contract"
-};
-
-const demoSystemAuthorization = {
-  userId: "mock-user-001",
-  authorizedSystems: [
-    {
-      systemId: "mock-system-001",
-      systemName: "Demo System",
-      role: "owner",
-      canRead: true,
-      canWrite: false,
-      selected: true
-    }
-  ]
-};
-
-function baseEnvelope(endpoint, method) {
-  return {
-    contractVersion: contractVersion,
-    endpoint: endpoint,
-    method: method,
-    transport: "planned REST API",
-    mockOnly: true,
-    canWrite: false,
-    usesPrivateData: false
-  };
-}
-
-function currentSessionSummary() {
-  return {
-    isAuthenticated: mockSession.isAuthenticated,
-    user: mockSession.user,
-    selectedSystemId: mockSession.selectedSystemId
-  };
-}
-
-function loginSuccess(username) {
-  mockSession.isAuthenticated = true;
-  mockSession.user = Object.assign({}, demoUser, {
-    username: username || demoUser.username
-  });
-  mockSession.selectedSystemId = "mock-system-001";
-
-  return Object.assign({}, baseEnvelope("/api/session/login", "POST"), {
-    result: "authenticated",
-    session: currentSessionSummary(),
-    userToSystemMapping: demoSystemAuthorization,
-    note: "Authentication creates a user session first. System access is supplied by explicit authorization mapping."
-  });
-}
-
-function loginFailure() {
-  mockSession.isAuthenticated = false;
-  mockSession.user = null;
-  mockSession.selectedSystemId = null;
-
-  return Object.assign({}, baseEnvelope("/api/session/login", "POST"), {
-    result: "rejected",
-    errorCode: "INVALID_CREDENTIALS",
-    session: currentSessionSummary(),
-    userToSystemMapping: {
-      userId: null,
-      authorizedSystems: []
-    },
-    note: "Failed authentication yields no user identity and no System authorization."
-  });
-}
-
-function logout() {
-  mockSession.isAuthenticated = false;
-  mockSession.user = null;
-  mockSession.selectedSystemId = null;
-
-  return Object.assign({}, baseEnvelope("/api/session/logout", "POST"), {
-    result: "signed out",
-    session: currentSessionSummary(),
-    userToSystemMapping: {
-      userId: null,
-      authorizedSystems: []
-    }
-  });
-}
-
-function sessionContract() {
-  return Object.assign({}, baseEnvelope("/api/session", "GET"), {
-    session: currentSessionSummary(),
-    note: "Session state reports authentication only. It does not imply access to any System."
-  });
-}
-
-function systemMappingContract() {
-  return Object.assign({}, baseEnvelope("/api/session/systems", "GET"), {
-    session: currentSessionSummary(),
-    userToSystemMapping: mockSession.isAuthenticated ? demoSystemAuthorization : {
-      userId: null,
-      authorizedSystems: []
-    },
-    note: "The authenticated user and authorized System are separate contract objects."
-  });
-}
-
-const contracts = {
-  me: Object.assign({}, baseEnvelope("/api/me", "GET"), {
-    authRequired: true,
-    session: currentSessionSummary(),
-    response: {
-      userId: "mock-user-001",
-      username: "demo.user",
-      displayName: "Demo User",
-      selectedSystemId: "mock-system-001"
-    }
-  }),
-  system: Object.assign({}, baseEnvelope("/api/systems/{systemId}", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      systemId: "mock-system-001",
-      displayName: "Demo System",
-      sourceSystem: "APPARYLLIS",
-      importedSystemCount: 1
-    }
-  }),
-  members: Object.assign({}, baseEnvelope("/api/systems/{systemId}/members", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      count: 49,
-      items: [
-        {
-          memberId: "mock-member-001",
-          displayName: "Member 001",
-          privacyBucket: "public"
-        }
-      ]
-    }
-  }),
-  frontHistory: Object.assign({}, baseEnvelope("/api/systems/{systemId}/front-history", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      count: 886,
-      items: [
-        {
-          frontHistoryId: "mock-front-history-001",
-          memberId: "mock-member-001",
-          startedAtUtc: "2026-01-01T00:00:00Z",
-          endedAtUtc: "2026-01-01T01:00:00Z"
-        }
-      ]
-    }
-  }),
-  privacyBuckets: Object.assign({}, baseEnvelope("/api/systems/{systemId}/privacy-buckets", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      count: 2,
-      items: [
-        {
-          privacyBucketId: "mock-privacy-bucket-public",
-          name: "public"
-        },
-        {
-          privacyBucketId: "mock-privacy-bucket-private",
-          name: "private"
-        }
-      ]
-    }
-  }),
-  customFields: Object.assign({}, baseEnvelope("/api/systems/{systemId}/custom-fields", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      count: 7,
-      items: [
-        {
-          customFieldId: "mock-custom-field-001",
-          name: "example field",
-          fieldType: "text"
-        }
-      ]
-    }
-  }),
-  importMetadata: Object.assign({}, baseEnvelope("/api/systems/{systemId}/import-metadata", "GET"), {
-    authRequired: true,
-    systemAuthorizationRequired: true,
-    response: {
-      importBatchCount: 1,
-      sourceRecordCount: 945,
-      sourceIdMapCount: 945,
-      sourceSystemCount: 1
-    }
-  })
-};
+let selectedSystemId = null;
 
 const output = document.getElementById("appOutput");
 const contractButtons = document.querySelectorAll("[data-contract]");
 const sessionButtons = document.querySelectorAll("[data-session-action]");
 const loginForm = document.getElementById("loginForm");
-const usernameInput = document.getElementById("username");
 const sessionStatus = document.getElementById("sessionStatus");
 
-function updateSessionStatus() {
-  if (mockSession.isAuthenticated) {
-    sessionStatus.textContent = "Session: signed in as " + mockSession.user.username + ", selected System " + mockSession.selectedSystemId;
-  } else {
-    sessionStatus.textContent = "Session: signed out";
+const endpointBuilders = {
+  me: async function() {
+    return "/api/me";
+  },
+  sourceSystems: async function() {
+    return "/api/source-systems";
+  },
+  importBatches: async function() {
+    return "/api/import-batches";
+  },
+  systems: async function() {
+    return "/api/systems";
+  },
+  members: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/members";
+  },
+  privacyBuckets: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/privacy-buckets";
+  },
+  customFields: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/custom-fields";
+  },
+  frontHistory: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/front-history";
+  },
+  sourceRecords: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/source-records";
+  },
+  sourceIdMappings: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/source-id-mappings";
+  },
+  importMetadata: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/import-metadata";
   }
+};
+
+function updateSessionStatus() {
+  sessionStatus.textContent = "Phase 2B: read-only database surface";
 }
 
 function renderPayload(payload) {
@@ -225,61 +53,113 @@ function renderPayload(payload) {
   updateSessionStatus();
 }
 
-function renderContract(key) {
-  contractButtons.forEach(function(button) {
-    button.setAttribute("aria-pressed", String(button.dataset.contract === key));
-  });
-  sessionButtons.forEach(function(button) {
-    button.setAttribute("aria-pressed", "false");
-  });
-  renderPayload(Object.assign({}, contracts[key], {
-    session: currentSessionSummary(),
-    userToSystemMapping: systemMappingContract().userToSystemMapping
-  }));
+function apiUrl(endpoint) {
+  const base = apiBaseUrl.endsWith("/") ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
+  return base + endpoint;
 }
 
-function renderSessionAction(action) {
+async function fetchJson(endpoint) {
+  const response = await fetch(apiUrl(endpoint), {
+    headers: {
+      Accept: "application/json"
+    }
+  });
+
+  const responseText = await response.text();
+  const payload = responseText ? JSON.parse(responseText) : null;
+
+  if (!response.ok) {
+    throw new Error("API request failed with HTTP " + response.status);
+  }
+
+  return payload;
+}
+
+async function getProofSystemId() {
+  if (selectedSystemId) {
+    return selectedSystemId;
+  }
+
+  const payload = await fetchJson("/api/me");
+
+  if (!payload || !payload.proofSystem || !payload.proofSystem.systemId) {
+    throw new Error("No proof system was returned by /api/me.");
+  }
+
+  selectedSystemId = payload.proofSystem.systemId;
+  return selectedSystemId;
+}
+
+function setContractButtonState(selectedKey) {
   contractButtons.forEach(function(button) {
-    button.setAttribute("aria-pressed", "false");
+    button.setAttribute("aria-pressed", String(button.dataset.contract === selectedKey));
   });
+}
+
+function setSessionButtonState(selectedAction) {
   sessionButtons.forEach(function(button) {
-    button.setAttribute("aria-pressed", String(button.dataset.sessionAction === action));
+    button.setAttribute("aria-pressed", String(button.dataset.sessionAction === selectedAction));
+  });
+}
+
+async function renderContract(key) {
+  const endpointBuilder = endpointBuilders[key];
+
+  setContractButtonState(key);
+  setSessionButtonState(null);
+
+  if (!endpointBuilder) {
+    renderPayload({
+      phase: "Phase 2B",
+      canWrite: false,
+      error: "Unknown read-only action",
+      action: key
+    });
+    return;
+  }
+
+  renderPayload({
+    phase: "Phase 2B",
+    canWrite: false,
+    action: key,
+    status: "loading"
   });
 
-  if (action === "login") {
-    renderPayload(loginSuccess(usernameInput.value.trim()));
-    return;
+  try {
+    const endpoint = await endpointBuilder();
+    const payload = await fetchJson(endpoint);
+    renderPayload(payload);
+  } catch (error) {
+    renderPayload({
+      phase: "Phase 2B",
+      canWrite: false,
+      action: key,
+      error: error.name || "Error",
+      message: error.message
+    });
   }
+}
 
-  if (action === "loginFailure") {
-    renderPayload(loginFailure());
-    return;
-  }
-
-  if (action === "session") {
-    renderPayload(sessionContract());
-    return;
-  }
-
-  if (action === "systemMapping") {
-    renderPayload(systemMappingContract());
-    return;
-  }
-
-  if (action === "logout") {
-    renderPayload(logout());
-  }
+function renderFrozenSessionAction(action) {
+  setContractButtonState(null);
+  setSessionButtonState(action);
+  renderPayload({
+    phase: "Phase 2B",
+    action: action,
+    canWrite: false,
+    status: "Phase 3A login/session contract is frozen while Phase 2B completes the database-backed read-only surface."
+  });
 }
 
 loginForm.addEventListener("submit", function(event) {
   event.preventDefault();
-  renderSessionAction("login");
+  renderFrozenSessionAction("login");
 });
 
 sessionButtons.forEach(function(button) {
   if (button.dataset.sessionAction !== "login") {
     button.addEventListener("click", function() {
-      renderSessionAction(button.dataset.sessionAction);
+      renderFrozenSessionAction(button.dataset.sessionAction);
     });
   }
 });

--- a/app/index.html
+++ b/app/index.html
@@ -10,9 +10,9 @@
   <main class="app-shell" aria-labelledby="app-title">
     <section class="app-card">
       <p class="eyebrow">PluralBridge application proof</p>
-      <h1 id="app-title">Phase 3: login and session contract</h1>
-      <p>Static planned-contract responses for login, logout, session state, authorized System mapping, and the validated 1-6 read-only slice.</p>
-      <p>No API connection, no Azure connection, no private data, and no write path beyond local mock session state.</p>
+      <h1 id="app-title">Phase 2B: complete read-only database surface</h1>
+      <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
+      <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
 
       <form id="loginForm" class="login-panel">
         <div class="field-row">
@@ -34,13 +34,17 @@
 
       <div id="sessionStatus" class="session-status">Session: signed out</div>
 
-      <div class="button-row" aria-label="Read-only contract actions">
+      <div class="button-row" aria-label="Read-only database actions">
         <button type="button" data-contract="me">me</button>
-        <button type="button" data-contract="system">system</button>
+        <button type="button" data-contract="sourceSystems">source systems</button>
+        <button type="button" data-contract="importBatches">import batches</button>
+        <button type="button" data-contract="systems">systems</button>
         <button type="button" data-contract="members">members</button>
-        <button type="button" data-contract="frontHistory">front history</button>
         <button type="button" data-contract="privacyBuckets">privacy buckets</button>
         <button type="button" data-contract="customFields">custom fields</button>
+        <button type="button" data-contract="frontHistory">front history</button>
+        <button type="button" data-contract="sourceRecords">source records</button>
+        <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
         <button type="button" data-contract="importMetadata">import metadata</button>
       </div>
 


### PR DESCRIPTION
Releases v0.7.0 to production.

Includes:

* Phase 2B completed as a real database-backed read-only browser/API proof
* New ASP.NET Core C# REST API under `api/`
* Read-only endpoints for `me`, source systems, import batches, systems, members, privacy buckets, custom fields, front history, source records, source ID mappings, and import metadata
* Azure SQL proof database reads through `Microsoft.Data.SqlClient`
* Browser app fetch wiring for all Phase 2B read-only buttons
* Output-box CSS fix for large JSON payloads
* Visual Studio/.NET ignore rules
* `TAG_TASKS.md` v0.7.0 release-history entry

Validation:

* `/api/me` returns proof counts matching the validated 1-6 slice
* Browser buttons return real API data
* Counts validated:

  * source systems: 1
  * import batches: 1
  * systems: 1
  * members: 49
  * privacy buckets: 2
  * custom fields: 7
  * front history: 886
  * source records: 945
  * source ID mappings: 945
* `canWrite` remains false
* Raw source JSON is not exposed
* No secrets committed

Release intent:

* Tag this production release as `v0.7.0` after merge.
