### PR TITLE
Add protected browser button app proof

### DIFF
--- a/api/PluralBridge.Api/PluralBridge.Api/Program.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Program.cs
@@ -1,8 +1,27 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication;
+using System.Security.Claims;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-
 builder.Services.AddControllers();
+
+builder.Services
+	.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+	.AddCookie(options =>
+	{
+		options.Cookie.Name = "PluralBridgeProofAuth";
+		options.Cookie.Path = "/";
+		options.Cookie.HttpOnly = true;
+		options.Cookie.SameSite = SameSiteMode.Lax;
+		options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+		options.LoginPath = "/login";
+		options.LogoutPath = "/logout";
+		options.AccessDeniedPath = "/login";
+	});
+
+builder.Services.AddAuthorization();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -34,9 +53,115 @@ if (app.Environment.IsDevelopment())
 	// allow cross domain requests
 	app.UseCors("Phase2BLocalBrowserProof");
 }
+
+// enable authentication
+app.UseAuthentication();
+
+// enable authorization middleware
 app.UseAuthorization();
 
-// add endpoints
-app.MapControllers();
+// add static app redirects
+app.MapGet("/", () => Results.Redirect("/app/"));
+
+// require login for the browser button app files
+app.MapGet("/app/", () =>
+{
+	var path = Path.Combine(app.Environment.WebRootPath!, "app", "index.html");
+
+	return Results.File(path, "text/html");
+}).RequireAuthorization();
+
+app.MapGet("/app/app.css", () =>
+{
+	var path = Path.Combine(app.Environment.WebRootPath!, "app", "app.css");
+
+	return Results.File(path, "text/css");
+}).RequireAuthorization();
+
+app.MapGet("/app/app.js", () =>
+{
+	var path = Path.Combine(app.Environment.WebRootPath!, "app", "app.js");
+
+	return Results.File(path, "text/javascript");
+}).RequireAuthorization();
+
+// add login page endpoint
+app.MapGet("/login", () =>
+{
+	const string loginPage =
+		"<!doctype html>" +
+		"<html lang=\"en\">" +
+		"<head>" +
+		"<meta charset=\"utf-8\">" +
+		"<title>PluralBridge Demo Login</title>" +
+		"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" +
+		"</head>" +
+		"<body>" +
+		"<main>" +
+		"<h1>PluralBridge Demo Login</h1>" +
+		"<p>Private Phase 2B engineering proof.</p>" +
+		"<form method=\"post\" action=\"/login\">" +
+		"<label for=\"userName\">Username</label><br>" +
+		"<input id=\"userName\" name=\"userName\" autocomplete=\"username\" required><br><br>" +
+		"<label for=\"password\">Password</label><br>" +
+		"<input id=\"password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required><br><br>" +
+		"<button type=\"submit\">Sign in</button>" +
+		"</form>" +
+		"</main>" +
+		"</body>" +
+		"</html>";
+
+	return Results.Content(loginPage, "text/html");
+});
+
+// add login form post endpoint
+app.MapPost("/login", async (HttpContext context, IConfiguration configuration) =>
+{
+	var form = await context.Request.ReadFormAsync();
+
+	var userName = form["userName"].FirstOrDefault() ?? string.Empty;
+	var password = form["password"].FirstOrDefault() ?? string.Empty;
+
+	var configuredUserName = configuration["ProtectedDemo:UserName"] ?? string.Empty;
+	var configuredPassword = configuration["ProtectedDemo:Password"] ?? string.Empty;
+
+	if (string.IsNullOrWhiteSpace(configuredUserName) ||
+	    string.IsNullOrWhiteSpace(configuredPassword) ||
+	    !string.Equals(userName, configuredUserName, StringComparison.Ordinal) ||
+	    !string.Equals(password, configuredPassword, StringComparison.Ordinal))
+	{
+		return Results.Redirect("/login");
+	}
+
+	var claims = new List<Claim>
+	{
+		new(ClaimTypes.Name, configuredUserName)
+	};
+
+	var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+	var principal = new ClaimsPrincipal(identity);
+
+	await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+
+	return Results.Redirect("/app/");
+});
+
+// add logout endpoint
+app.MapPost("/logout", async (HttpContext context) =>
+{
+	await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+	return Results.Redirect("/login");
+}).RequireAuthorization();
+
+// temporary auth diagnostic endpoint
+app.MapGet("/whoami", (HttpContext context) => Results.Json(new
+{
+	isAuthenticated = context.User.Identity?.IsAuthenticated ?? false,
+	name = context.User.Identity?.Name ?? string.Empty
+}));
+
+// add API controller endpoints
+app.MapControllers().RequireAuthorization();
 
 app.Run();

--- a/api/PluralBridge.Api/PluralBridge.Api/Program.cs
+++ b/api/PluralBridge.Api/PluralBridge.Api/Program.cs
@@ -154,12 +154,14 @@ app.MapPost("/logout", async (HttpContext context) =>
 	return Results.Redirect("/login");
 }).RequireAuthorization();
 
+#if DEBUG_MODE
 // temporary auth diagnostic endpoint
 app.MapGet("/whoami", (HttpContext context) => Results.Json(new
 {
 	isAuthenticated = context.User.Identity?.IsAuthenticated ?? false,
 	name = context.User.Identity?.Name ?? string.Empty
 }));
+#endif
 
 // add API controller endpoints
 app.MapControllers().RequireAuthorization();

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.css
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.css
@@ -1,0 +1,132 @@
+:root {
+  color-scheme: dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101418;
+  color: #f4f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #243447, #101418 55%);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.app-card {
+  width: min(960px, 100%);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 1.25rem;
+  background: rgba(16, 20, 24, 0.86);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #a8c7ff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+}
+
+p {
+  max-width: 70ch;
+  color: #d8e1ed;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  color: #101418;
+  background: #a8c7ff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus-visible,
+button[aria-pressed="true"] {
+  background: #f4f7fb;
+  outline: 2px solid #a8c7ff;
+  outline-offset: 3px;
+}
+
+.output-box {
+  min-height: 22rem;
+  max-height: 34rem;
+  overflow: auto;
+  margin: 0;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.8rem;
+  background: #070a0d;
+  color: #d8e1ed;
+  font-size: 0.92rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.login-panel {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.field-row {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.field-row label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.field-row input {
+  width: min(100%, 24rem);
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 0.5rem;
+  color: #e5e7eb;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.session-status {
+  margin: 0 0 1rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.65rem;
+  font-weight: 700;
+  color: #dbeafe;
+  background: rgba(30, 64, 175, 0.28);
+}

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.js
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.js
@@ -1,0 +1,204 @@
+const apiBaseUrl = "";
+
+let selectedSystemId = null;
+
+const output = document.getElementById("appOutput");
+const contractButtons = document.querySelectorAll("[data-contract]");
+const sessionButtons = document.querySelectorAll("[data-session-action]");
+const loginForm = document.getElementById("loginForm");
+const sessionStatus = document.getElementById("sessionStatus");
+
+const endpointBuilders = {
+  me: async function() {
+    return "/api/me";
+  },
+  sourceSystems: async function() {
+    return "/api/source-systems";
+  },
+  importBatches: async function() {
+    return "/api/import-batches";
+  },
+  systems: async function() {
+    return "/api/systems";
+  },
+  members: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/members";
+  },
+  privacyBuckets: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/privacy-buckets";
+  },
+  customFields: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/custom-fields";
+  },
+  frontHistory: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/front-history";
+  },
+  sourceRecords: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/source-records";
+  },
+  sourceIdMappings: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/source-id-mappings";
+  },
+  importMetadata: async function() {
+    return "/api/systems/" + (await getProofSystemId()) + "/import-metadata";
+  }
+};
+
+function updateSessionStatus() {
+  sessionStatus.textContent = "Phase 2B: read-only database surface";
+}
+
+function renderPayload(payload) {
+  output.textContent = JSON.stringify(payload, null, 2);
+  updateSessionStatus();
+}
+
+function apiUrl(endpoint) {
+  const base = apiBaseUrl.endsWith("/") ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
+  return base + endpoint;
+}
+
+async function fetchJson(endpoint) {
+  const response = await fetch(apiUrl(endpoint), {
+    headers: {
+      Accept: "application/json"
+    }
+  });
+
+  const responseText = await response.text();
+  const payload = responseText ? JSON.parse(responseText) : null;
+
+  if (!response.ok) {
+    throw new Error("API request failed with HTTP " + response.status);
+  }
+
+  return payload;
+}
+
+async function getProofSystemId() {
+  if (selectedSystemId) {
+    return selectedSystemId;
+  }
+
+  const payload = await fetchJson("/api/me");
+
+  if (!payload || !payload.proofSystem || !payload.proofSystem.systemId) {
+    throw new Error("No proof system was returned by /api/me.");
+  }
+
+  selectedSystemId = payload.proofSystem.systemId;
+  return selectedSystemId;
+}
+
+function setContractButtonState(selectedKey) {
+  contractButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", String(button.dataset.contract === selectedKey));
+  });
+}
+
+function setSessionButtonState(selectedAction) {
+  sessionButtons.forEach(function(button) {
+    button.setAttribute("aria-pressed", String(button.dataset.sessionAction === selectedAction));
+  });
+}
+
+async function renderContract(key) {
+  const endpointBuilder = endpointBuilders[key];
+
+  setContractButtonState(key);
+  setSessionButtonState(null);
+
+  if (!endpointBuilder) {
+    renderPayload({
+      phase: "Phase 2B",
+      canWrite: false,
+      error: "Unknown read-only action",
+      action: key
+    });
+    return;
+  }
+
+  renderPayload({
+    phase: "Phase 2B",
+    canWrite: false,
+    action: key,
+    status: "loading"
+  });
+
+  try {
+    const endpoint = await endpointBuilder();
+    const payload = await fetchJson(endpoint);
+    renderPayload(payload);
+  } catch (error) {
+    renderPayload({
+      phase: "Phase 2B",
+      canWrite: false,
+      action: key,
+      error: error.name || "Error",
+      message: error.message
+    });
+  }
+}
+
+function renderFrozenSessionAction(action) {
+  setContractButtonState(null);
+  setSessionButtonState(action);
+  renderPayload({
+    phase: "Phase 2B",
+    action: action,
+    canWrite: false,
+    status: "Phase 3A login/session contract is frozen while Phase 2B completes the database-backed read-only surface."
+  });
+}
+
+async function logout() {
+  try {
+    const response = await fetch("/logout", {
+      method: "POST",
+      credentials: "same-origin"
+    });
+
+    if (response.redirected) {
+      window.location.href = response.url;
+      return;
+    }
+
+    window.location.href = "/login";
+  } catch (error) {
+    renderPayload({
+      phase: "Phase 2B",
+      action: "logout",
+      canWrite: false,
+      error: error.name || "Error",
+      message: error.message
+    });
+  }
+}
+
+loginForm.addEventListener("submit", function(event) {
+  event.preventDefault();
+  renderFrozenSessionAction("login");
+});
+
+sessionButtons.forEach(function(button) {
+  if (button.dataset.sessionAction !== "login") {
+    button.addEventListener("click", function() {
+      const action = button.dataset.sessionAction;
+
+      if (action === "logout") {
+        logout();
+        return;
+      }
+
+      renderFrozenSessionAction(action);
+    });
+  }
+});
+
+contractButtons.forEach(function(button) {
+  button.addEventListener("click", function() {
+    renderContract(button.dataset.contract);
+  });
+});
+
+updateSessionStatus();

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/index.html
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PluralBridge App Proof</title>
+  <link rel="stylesheet" href="./app.css">
+</head>
+<body>
+  <main class="app-shell" aria-labelledby="app-title">
+    <section class="app-card">
+      <p class="eyebrow">PluralBridge application proof</p>
+      <h1 id="app-title">Phase 2B: complete read-only database surface</h1>
+      <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
+      <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
+
+      <form id="loginForm" class="login-panel">
+        <div class="field-row">
+          <label for="username">Username</label>
+          <input id="username" name="username" autocomplete="username" value="demo.user">
+        </div>
+        <div class="field-row">
+          <label for="password">Password</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" value="pluralbridge-demo">
+        </div>
+        <div class="button-row" aria-label="Session contract actions">
+          <button type="submit" data-session-action="login">login</button>
+          <button type="button" data-session-action="loginFailure">login failure</button>
+          <button type="button" data-session-action="session">session</button>
+          <button type="button" data-session-action="systemMapping">system mapping</button>
+          <button type="button" data-session-action="logout">logout</button>
+        </div>
+      </form>
+
+      <div id="sessionStatus" class="session-status">Session: signed out</div>
+
+      <div class="button-row" aria-label="Read-only database actions">
+        <button type="button" data-contract="me">me</button>
+        <button type="button" data-contract="sourceSystems">source systems</button>
+        <button type="button" data-contract="importBatches">import batches</button>
+        <button type="button" data-contract="systems">systems</button>
+        <button type="button" data-contract="members">members</button>
+        <button type="button" data-contract="privacyBuckets">privacy buckets</button>
+        <button type="button" data-contract="customFields">custom fields</button>
+        <button type="button" data-contract="frontHistory">front history</button>
+        <button type="button" data-contract="sourceRecords">source records</button>
+        <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
+        <button type="button" data-contract="importMetadata">import metadata</button>
+      </div>
+
+      <pre id="appOutput" class="output-box" aria-live="polite">{ }</pre>
+    </section>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds the protected browser button app proof for the Azure-hosted API demo.

Includes:
- Cookie-auth protected /app/ browser proof
- Protected copied static app files under the API project
- Protected /api/* controller surface
- Login/logout endpoints
- User-secret/App Service configuration support for demo credentials
- /whoami diagnostic endpoint guarded behind DEBUG_MODE

Validated:
- Local build passed
- Local login → app → me → logout smoke test passed
- Azure ZIP deployment passed
- Azure login → app → me → logout smoke test passed