### PR TITLE
Release v0.7.3 demo UI polish

### DIFF
--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -1,3 +1,12 @@
+## v0.7.3 — Demo UI polish
+
+- Replaced the in-app login proof panel with a compact protected-session strip and logout action.
+- Added friendly read-only demo views for every app button.
+- Rendered members, front history, source systems, systems, privacy buckets, custom fields, import batches, source records, source ID mappings, import metadata, and demo session data as readable cards/rows.
+- Kept raw JSON available behind row expanders for proof and verification.
+- Updated the app page title to “Explore the PluralBridge read-only demo.”
+- Preserved the served/root app split and the required apiBaseUrl difference.
+
 # PluralBridge Tag Task History
 
 This file records the major work represented by each repository tag. It is intended as a project-facing release/task history for the repository root.

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.css
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.css
@@ -100,6 +100,31 @@ button[aria-pressed="true"] {
   background: rgba(15, 23, 42, 0.28);
 }
 
+.login-panel {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.session-summary {
+	display: grid;
+	gap: 0.25rem;
+}
+
+	.session-summary strong {
+		color: #f4f7fb;
+	}
+
+	.session-summary span {
+		color: #d8e1ed;
+	}
+
+.login-panel .button-row {
+	margin: 0;
+}
+
 .field-row {
   display: grid;
   gap: 0.35rem;
@@ -129,4 +154,229 @@ button[aria-pressed="true"] {
   font-weight: 700;
   color: #dbeafe;
   background: rgba(30, 64, 175, 0.28);
+}
+
+.json-output {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.output-heading {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+
+.output-note {
+  margin: 0 0 1rem;
+  color: #cbd5e1;
+}
+
+.member-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.member-card {
+  border: 1px solid rgba(168, 199, 255, 0.28);
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.member-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+}
+
+.member-name {
+  font-weight: 800;
+}
+
+.member-pronouns {
+  color: #a8c7ff;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.member-body {
+  padding: 0 1rem 1rem;
+}
+
+.member-toggle-row {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.member-toggle-button {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.member-content {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 0.75rem;
+}
+
+.member-description {
+  margin: 0;
+}
+
+.member-json {
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.85rem;
+  border-radius: 0.65rem;
+  background: #070a0d;
+}
+
+.me-fields {
+	display: grid;
+	gap: 0.65rem;
+	margin-bottom: 1rem;
+}
+
+.me-field {
+	display: grid;
+	grid-template-columns: 10rem minmax(0, 1fr);
+	gap: 0.75rem;
+}
+
+.me-label,
+.me-count-label {
+	color: #a8c7ff;
+	font-size: 0.85rem;
+	font-weight: 700;
+}
+
+.me-value {
+	color: #f4f7fb;
+	overflow-wrap: anywhere;
+}
+
+.me-section-heading {
+	margin: 1rem 0 0.75rem;
+	font-size: 1rem;
+}
+
+.me-count-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.me-count {
+	padding: 0.85rem;
+	border: 1px solid rgba(168, 199, 255, 0.22);
+	border-radius: 0.75rem;
+	background: rgba(7, 10, 13, 0.42);
+}
+
+.me-count-value {
+	display: block;
+	color: #f4f7fb;
+	font-size: 1.35rem;
+	font-weight: 800;
+}
+
+.me-json-details summary {
+	cursor: pointer;
+	color: #a8c7ff;
+	font-weight: 700;
+}
+
+.member-summary {
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
+	.member-summary::marker {
+		content: "";
+	}
+
+	.member-summary::-webkit-details-marker {
+		display: none;
+	}
+
+.member-identity {
+	display: grid;
+	gap: 0.2rem;
+}
+
+.member-pronouns {
+	justify-self: start;
+}
+
+.member-chevron {
+	align-self: center;
+	color: #a8c7ff;
+	font-weight: 900;
+	transition: transform 0.15s ease;
+}
+
+.member-card[open] .member-chevron {
+	transform: rotate(180deg);
+}
+
+.front-history-list {
+	display: grid;
+	gap: 0.75rem;
+}
+
+.front-history-card {
+	border: 1px solid rgba(168, 199, 255, 0.28);
+	border-radius: 0.85rem;
+	background: rgba(15, 23, 42, 0.55);
+}
+
+.front-history-summary {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto auto;
+	gap: 1rem;
+	align-items: center;
+	padding: 0.9rem 1rem;
+	cursor: pointer;
+}
+
+	.front-history-summary::marker {
+		content: "";
+	}
+
+	.front-history-summary::-webkit-details-marker {
+		display: none;
+	}
+
+.front-history-name {
+	font-weight: 800;
+}
+
+.front-history-time {
+	color: #a8c7ff;
+	font-size: 0.9rem;
+	font-weight: 700;
+	text-align: right;
+}
+
+.front-history-chevron {
+	align-self: center;
+	color: #a8c7ff;
+	font-weight: 900;
+	transition: transform 0.15s ease;
+}
+
+.front-history-card[open] .front-history-chevron {
+	transform: rotate(180deg);
+}
+
+.front-history-json {
+	max-height: 18rem;
+	overflow: auto;
+	margin: 0 1rem 1rem;
+	padding: 0.85rem;
+	border-radius: 0.65rem;
+	background: #070a0d;
 }

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.js
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/app.js
@@ -1,4 +1,4 @@
-const apiBaseUrl = "";
+﻿const apiBaseUrl = "";
 
 let selectedSystemId = null;
 
@@ -45,12 +45,1378 @@ const endpointBuilders = {
 };
 
 function updateSessionStatus() {
-  sessionStatus.textContent = "Phase 2B: read-only database surface";
+    sessionStatus.textContent = "You are signed in to the read-only PluralBridge demo.";
+}
+
+function clearOutput() {
+    output.replaceChildren();
 }
 
 function renderPayload(payload) {
-  output.textContent = JSON.stringify(payload, null, 2);
-  updateSessionStatus();
+    clearOutput();
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    output.appendChild(jsonBlock);
+    updateSessionStatus();
+}
+
+function getSourceSystemsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceSystems)) {
+        return payload.sourceSystems;
+    }
+
+    return [];
+}
+
+function getSourceSystemDisplayName(sourceSystem) {
+    if (sourceSystem && sourceSystem.displayName) {
+        return sourceSystem.displayName;
+    }
+
+    if (sourceSystem && sourceSystem.sourceSystemCode) {
+        return sourceSystem.sourceSystemCode;
+    }
+
+    return "(unnamed source system)";
+}
+
+function getSourceSystemCode(sourceSystem) {
+    return sourceSystem && sourceSystem.sourceSystemCode ? sourceSystem.sourceSystemCode : "";
+}
+
+function createSourceSystemAccordion(sourceSystem) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceSystemDisplayName(sourceSystem);
+
+    const code = document.createElement("span");
+    code.className = "member-pronouns";
+    code.textContent = getSourceSystemCode(sourceSystem);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(code);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(sourceSystem, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceSystems(payload) {
+    clearOutput();
+
+    const sourceSystems = getSourceSystemsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source systems";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceSystems.length + " source systems returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceSystems.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source systems were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceSystems.forEach(function (sourceSystem) {
+            wrapper.appendChild(createSourceSystemAccordion(sourceSystem));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSystemsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.systems)) {
+        return payload.systems;
+    }
+
+    return [];
+}
+
+function getSystemDisplayName(system) {
+    if (system && system.systemName) {
+        return system.systemName;
+    }
+
+    return "(unnamed system)";
+}
+
+function getSystemSubtitle(system) {
+    if (system && system.description) {
+        return system.description;
+    }
+
+    if (system && system.systemId) {
+        return system.systemId;
+    }
+
+    return "";
+}
+
+function createSystemAccordion(system) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSystemDisplayName(system);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSystemSubtitle(system);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(system, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSystems(payload) {
+    clearOutput();
+
+    const systems = getSystemsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Systems";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = systems.length + " systems returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (systems.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No systems were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        systems.forEach(function (system) {
+            wrapper.appendChild(createSystemAccordion(system));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function createMeField(labelText, valueText) {
+    const item = document.createElement("div");
+    item.className = "me-field";
+
+    const label = document.createElement("span");
+    label.className = "me-label";
+    label.textContent = labelText;
+
+    const value = document.createElement("span");
+    value.className = "me-value";
+    value.textContent = valueText || "(none)";
+
+    item.appendChild(label);
+    item.appendChild(value);
+
+    return item;
+}
+
+function createMeCount(labelText, valueText) {
+    const item = document.createElement("div");
+    item.className = "me-count";
+
+    const value = document.createElement("span");
+    value.className = "me-count-value";
+    value.textContent = String(valueText);
+
+    const label = document.createElement("span");
+    label.className = "me-count-label";
+    label.textContent = labelText;
+
+    item.appendChild(value);
+    item.appendChild(label);
+
+    return item;
+}
+
+function renderMe(payload) {
+    clearOutput();
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Demo session";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = "Read-only PluralBridge proof context for the protected demo session.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    const details = document.createElement("details");
+    details.className = "member-card";
+    details.open = true;
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = payload && payload.mode ? payload.mode : "read-only proof";
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = payload && payload.database ? payload.database : "";
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const fields = document.createElement("div");
+    fields.className = "me-fields";
+
+    fields.appendChild(createMeField("API", payload && payload.api ? payload.api : ""));
+    fields.appendChild(createMeField("Phase", payload && payload.phase ? payload.phase : ""));
+    fields.appendChild(createMeField("Write access", payload && payload.canWrite ? "enabled" : "disabled"));
+
+    if (payload && payload.proofSystem) {
+        fields.appendChild(createMeField("Proof system ID", payload.proofSystem.systemId || ""));
+        fields.appendChild(createMeField("Proof system name", payload.proofSystem.systemName || "(unnamed system)"));
+    }
+
+    body.appendChild(fields);
+
+    const countsHeading = document.createElement("h3");
+    countsHeading.className = "me-section-heading";
+    countsHeading.textContent = "Read-only record counts";
+    body.appendChild(countsHeading);
+
+    const countsGrid = document.createElement("div");
+    countsGrid.className = "me-count-grid";
+
+    if (payload && payload.counts) {
+        Object.keys(payload.counts).forEach(function (key) {
+            countsGrid.appendChild(createMeCount(key, payload.counts[key]));
+        });
+    }
+
+    body.appendChild(countsGrid);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    const jsonDetails = document.createElement("details");
+    jsonDetails.className = "me-json-details";
+
+    const jsonSummary = document.createElement("summary");
+    jsonSummary.textContent = "Raw JSON";
+
+    jsonDetails.appendChild(jsonSummary);
+    jsonDetails.appendChild(jsonBlock);
+    body.appendChild(jsonDetails);
+
+    details.appendChild(body);
+    wrapper.appendChild(details);
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getPrivacyBucketsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.privacyBuckets)) {
+        return payload.privacyBuckets;
+    }
+
+    return [];
+}
+
+function getPrivacyBucketName(bucket) {
+    return bucket && bucket.bucketName ? bucket.bucketName : "(unnamed privacy bucket)";
+}
+
+function getPrivacyBucketSubtitle(bucket) {
+    if (bucket && bucket.description) {
+        return bucket.description;
+    }
+
+    if (bucket && bucket.privacyBucketId) {
+        return bucket.privacyBucketId;
+    }
+
+    return "";
+}
+
+function createPrivacyBucketAccordion(bucket) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getPrivacyBucketName(bucket);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getPrivacyBucketSubtitle(bucket);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(bucket, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderPrivacyBuckets(payload) {
+    clearOutput();
+
+    const privacyBuckets = getPrivacyBucketsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Privacy buckets";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = privacyBuckets.length + " privacy buckets returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (privacyBuckets.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No privacy buckets were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        privacyBuckets.forEach(function (bucket) {
+            wrapper.appendChild(createPrivacyBucketAccordion(bucket));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getCustomFieldsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.customFields)) {
+        return payload.customFields;
+    }
+
+    return [];
+}
+
+function getCustomFieldName(customField) {
+    return customField && customField.fieldName ? customField.fieldName : "(unnamed custom field)";
+}
+
+function getCustomFieldSubtitle(customField) {
+    if (customField && customField.description) {
+        return customField.description;
+    }
+
+    if (customField && customField.fieldTypeCode !== null && customField.fieldTypeCode !== undefined) {
+        return "Field type code " + customField.fieldTypeCode;
+    }
+
+    if (customField && customField.customFieldId) {
+        return customField.customFieldId;
+    }
+
+    return "";
+}
+
+function createCustomFieldAccordion(customField) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getCustomFieldName(customField);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getCustomFieldSubtitle(customField);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(customField, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderCustomFields(payload) {
+    clearOutput();
+
+    const customFields = getCustomFieldsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Custom fields";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = customFields.length + " custom fields returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (customFields.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No custom fields were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        customFields.forEach(function (customField) {
+            wrapper.appendChild(createCustomFieldAccordion(customField));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getImportBatchesFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.importBatches)) {
+        return payload.importBatches;
+    }
+
+    return [];
+}
+
+function getImportBatchName(importBatch) {
+    if (importBatch && importBatch.sourceExportName) {
+        return importBatch.sourceExportName;
+    }
+
+    if (importBatch && importBatch.importToolName) {
+        return importBatch.importToolName;
+    }
+
+    if (importBatch && importBatch.importBatchId) {
+        return importBatch.importBatchId;
+    }
+
+    return "(unnamed import batch)";
+}
+
+function formatImportBatchTime(value) {
+    if (!value) {
+        return "";
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString();
+}
+
+function getImportBatchSubtitle(importBatch) {
+    if (!importBatch) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (importBatch.sourceSystemCode) {
+        parts.push(importBatch.sourceSystemCode);
+    }
+
+    if (importBatch.importCompletedAtUtc) {
+        parts.push("completed " + formatImportBatchTime(importBatch.importCompletedAtUtc));
+    } else if (importBatch.importStartedAtUtc) {
+        parts.push("started " + formatImportBatchTime(importBatch.importStartedAtUtc));
+    }
+
+    return parts.join(" · ");
+}
+
+function createImportBatchAccordion(importBatch) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getImportBatchName(importBatch);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getImportBatchSubtitle(importBatch);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(importBatch, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderImportBatches(payload) {
+    clearOutput();
+
+    const importBatches = getImportBatchesFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Import batches";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = importBatches.length + " import batches returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (importBatches.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No import batches were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        importBatches.forEach(function (importBatch) {
+            wrapper.appendChild(createImportBatchAccordion(importBatch));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSourceRecordsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceRecords)) {
+        return payload.sourceRecords;
+    }
+
+    return [];
+}
+
+function getSourceRecordName(sourceRecord) {
+    if (!sourceRecord) {
+        return "(unknown source record)";
+    }
+
+    if (sourceRecord.sourceEntityTypeCode && sourceRecord.sourceId) {
+        return sourceRecord.sourceEntityTypeCode + " · " + sourceRecord.sourceId;
+    }
+
+    if (sourceRecord.sourceEntityTypeCode) {
+        return sourceRecord.sourceEntityTypeCode;
+    }
+
+    if (sourceRecord.sourceRecordId) {
+        return sourceRecord.sourceRecordId;
+    }
+
+    return "(unknown source record)";
+}
+
+function getSourceRecordSubtitle(sourceRecord) {
+    if (!sourceRecord) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (sourceRecord.sourceSystemCode) {
+        parts.push(sourceRecord.sourceSystemCode);
+    }
+
+    if (sourceRecord.sourceEndpoint) {
+        parts.push(sourceRecord.sourceEndpoint);
+    }
+
+    return parts.join(" · ");
+}
+
+function createSourceRecordAccordion(sourceRecord) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceRecordName(sourceRecord);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSourceRecordSubtitle(sourceRecord);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(sourceRecord, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceRecords(payload) {
+    clearOutput();
+
+    const sourceRecords = getSourceRecordsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source records";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceRecords.length + " source records returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceRecords.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source records were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceRecords.forEach(function (sourceRecord) {
+            wrapper.appendChild(createSourceRecordAccordion(sourceRecord));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSourceIdMappingsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceIdMappings)) {
+        return payload.sourceIdMappings;
+    }
+
+    return [];
+}
+
+function getSourceIdMappingName(mapping) {
+    if (!mapping) {
+        return "(unknown source ID mapping)";
+    }
+
+    if (mapping.sourceEntityTypeCode && mapping.sourceId) {
+        return mapping.sourceEntityTypeCode + " · " + mapping.sourceId;
+    }
+
+    if (mapping.sourceEntityTypeCode) {
+        return mapping.sourceEntityTypeCode;
+    }
+
+    if (mapping.sourceIdMapId) {
+        return mapping.sourceIdMapId;
+    }
+
+    return "(unknown source ID mapping)";
+}
+
+function getSourceIdMappingSubtitle(mapping) {
+    if (!mapping) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (mapping.sourceSystemCode) {
+        parts.push(mapping.sourceSystemCode);
+    }
+
+    if (mapping.pluralBridgeEntityTypeCode && mapping.pluralBridgeId) {
+        parts.push(mapping.pluralBridgeEntityTypeCode + " → " + mapping.pluralBridgeId);
+    } else if (mapping.pluralBridgeEntityTypeCode) {
+        parts.push(mapping.pluralBridgeEntityTypeCode);
+    } else if (mapping.pluralBridgeId) {
+        parts.push(mapping.pluralBridgeId);
+    }
+
+    return parts.join(" · ");
+}
+
+function createSourceIdMappingAccordion(mapping) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceIdMappingName(mapping);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSourceIdMappingSubtitle(mapping);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(mapping, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceIdMappings(payload) {
+    clearOutput();
+
+    const sourceIdMappings = getSourceIdMappingsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source ID mappings";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceIdMappings.length + " source ID mappings returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceIdMappings.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source ID mappings were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceIdMappings.forEach(function (mapping) {
+            wrapper.appendChild(createSourceIdMappingAccordion(mapping));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function renderImportMetadata(payload) {
+    clearOutput();
+
+    const metadata = payload && payload.importMetadata ? payload.importMetadata : {};
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Import metadata";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = "Read-only import health and lineage summary for this demo system.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    const details = document.createElement("details");
+    details.className = "member-card";
+    details.open = true;
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = "Import status";
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = metadata.systemExists === true ? "system exists" : "system missing";
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const fields = document.createElement("div");
+    fields.className = "me-fields";
+
+    fields.appendChild(createMeField("System ID", payload && payload.systemId ? payload.systemId : ""));
+    fields.appendChild(createMeField("System exists", metadata.systemExists === true ? "yes" : "no"));
+
+    body.appendChild(fields);
+
+    const countsHeading = document.createElement("h3");
+    countsHeading.className = "me-section-heading";
+    countsHeading.textContent = "Import ledger counts";
+    body.appendChild(countsHeading);
+
+    const countsGrid = document.createElement("div");
+    countsGrid.className = "me-count-grid";
+
+    countsGrid.appendChild(createMeCount("source systems", metadata.sourceSystemCount));
+    countsGrid.appendChild(createMeCount("import batches", metadata.importBatchCount));
+    countsGrid.appendChild(createMeCount("source records", metadata.sourceRecordCount));
+    countsGrid.appendChild(createMeCount("source ID mappings", metadata.sourceIdMappingCount));
+
+    body.appendChild(countsGrid);
+
+    if (metadata.latestImportBatch) {
+        const batchHeading = document.createElement("h3");
+        batchHeading.className = "me-section-heading";
+        batchHeading.textContent = "Latest import batch";
+        body.appendChild(batchHeading);
+
+        body.appendChild(createImportBatchAccordion(metadata.latestImportBatch));
+    }
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    const jsonDetails = document.createElement("details");
+    jsonDetails.className = "me-json-details";
+
+    const jsonSummary = document.createElement("summary");
+    jsonSummary.textContent = "Raw JSON";
+
+    jsonDetails.appendChild(jsonSummary);
+    jsonDetails.appendChild(jsonBlock);
+    body.appendChild(jsonDetails);
+
+    details.appendChild(body);
+    wrapper.appendChild(details);
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getMembersFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.members)) {
+        return payload.members;
+    }
+
+    return [];
+}
+
+function getMemberDisplayName(member) {
+    return member && member.displayName ? member.displayName : "(unnamed member)";
+}
+
+function getMemberPronouns(member) {
+    return member && member.pronouns ? member.pronouns : "";
+}
+
+function getMemberDescription(member) {
+    return member && member.description ? member.description : "No description available.";
+}
+
+function createMemberAccordion(member) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getMemberDisplayName(member);
+
+    const pronouns = document.createElement("span");
+    pronouns.className = "member-pronouns";
+    pronouns.textContent = getMemberPronouns(member);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(pronouns);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const toggleRow = document.createElement("div");
+    toggleRow.className = "member-toggle-row";
+    toggleRow.setAttribute("aria-label", "Member detail display mode");
+
+    const descriptionButton = document.createElement("button");
+    descriptionButton.type = "button";
+    descriptionButton.className = "member-toggle-button";
+    descriptionButton.textContent = "Description";
+
+    const jsonButton = document.createElement("button");
+    jsonButton.type = "button";
+    jsonButton.className = "member-toggle-button";
+    jsonButton.textContent = "JSON";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const descriptionText = document.createElement("p");
+    descriptionText.className = "member-description";
+    descriptionText.textContent = getMemberDescription(member);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(member, null, 2);
+
+    function showDescription() {
+        descriptionButton.setAttribute("aria-pressed", "true");
+        jsonButton.setAttribute("aria-pressed", "false");
+        content.replaceChildren(descriptionText);
+    }
+
+    function showJson() {
+        descriptionButton.setAttribute("aria-pressed", "false");
+        jsonButton.setAttribute("aria-pressed", "true");
+        content.replaceChildren(jsonBlock);
+    }
+
+    descriptionButton.addEventListener("click", showDescription);
+    jsonButton.addEventListener("click", showJson);
+
+    toggleRow.appendChild(descriptionButton);
+    toggleRow.appendChild(jsonButton);
+
+    body.appendChild(toggleRow);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    showDescription();
+
+    return details;
+}
+
+function renderMembers(payload) {
+    clearOutput();
+
+    const members = getMembersFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Members";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = members.length + " members returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (members.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No members were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        members.forEach(function (member) {
+            wrapper.appendChild(createMemberAccordion(member));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getFrontHistoryFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.frontHistory)) {
+        return payload.frontHistory;
+    }
+
+    return [];
+}
+
+function getFrontHistoryName(record) {
+    return record && record.memberDisplayName ? record.memberDisplayName : "(unknown member)";
+}
+
+function formatFrontHistoryTime(value) {
+    if (!value) {
+        return "";
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return "";
+    }
+
+    return date.toLocaleString();
+}
+
+function getFrontHistoryTimeRange(record) {
+    const start = formatFrontHistoryTime(record.startTimeMs);
+
+    if (record.isLive) {
+        return start ? start + " – Live" : "Live";
+    }
+
+    const end = formatFrontHistoryTime(record.endTimeMs);
+
+    if (start && end) {
+        return start + " – " + end;
+    }
+
+    if (start) {
+        return start;
+    }
+
+    return "No time recorded";
+}
+
+function createFrontHistoryAccordion(record) {
+    const details = document.createElement("details");
+    details.className = "front-history-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "front-history-summary";
+
+    const name = document.createElement("span");
+    name.className = "front-history-name";
+    name.textContent = getFrontHistoryName(record);
+
+    const timeRange = document.createElement("span");
+    timeRange.className = "front-history-time";
+    timeRange.textContent = getFrontHistoryTimeRange(record);
+
+    const chevron = document.createElement("span");
+    chevron.className = "front-history-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    summary.appendChild(name);
+    summary.appendChild(timeRange);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "front-history-json json-output";
+    jsonBlock.textContent = JSON.stringify(record, null, 2);
+
+    details.appendChild(jsonBlock);
+
+    return details;
+}
+
+function renderFrontHistory(payload) {
+    clearOutput();
+
+    const records = getFrontHistoryFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "front-history-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Front History";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = records.length + " front history records returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (records.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No front history records were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        records.forEach(function (record) {
+            wrapper.appendChild(createFrontHistoryAccordion(record));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
 }
 
 function apiUrl(endpoint) {
@@ -126,9 +1492,34 @@ async function renderContract(key) {
   });
 
   try {
-    const endpoint = await endpointBuilder();
-    const payload = await fetchJson(endpoint);
-    renderPayload(payload);
+      const endpoint = await endpointBuilder();
+      const payload = await fetchJson(endpoint);
+
+      if (key === "me") {
+          renderMe(payload);
+      } else if (key === "sourceSystems") {
+          renderSourceSystems(payload);
+      } else if (key === "importBatches") {
+          renderImportBatches(payload);
+      } else if (key === "systems") {
+          renderSystems(payload);
+      } else if (key === "privacyBuckets") {
+          renderPrivacyBuckets(payload);
+      } else if (key === "customFields") {
+          renderCustomFields(payload);
+      } else if (key === "members") {
+          renderMembers(payload);
+      } else if (key === "frontHistory") {
+          renderFrontHistory(payload);
+      } else if (key === "sourceRecords") {
+          renderSourceRecords(payload);
+      } else if (key === "sourceIdMappings") {
+          renderSourceIdMappings(payload);
+      } else if (key === "importMetadata") {
+          renderImportMetadata(payload);
+      } else {
+          renderPayload(payload);
+      }
   } catch (error) {
     renderPayload({
       phase: "Phase 2B",

--- a/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/index.html
+++ b/api/PluralBridge.Api/PluralBridge.Api/wwwroot/app/index.html
@@ -8,48 +8,37 @@
 </head>
 <body>
   <main class="app-shell" aria-labelledby="app-title">
-    <section class="app-card">
-      <p class="eyebrow">PluralBridge application proof</p>
-      <h1 id="app-title">Phase 2B: complete read-only database surface</h1>
-      <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
-      <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
+      <section class="app-card">
+          <p class="eyebrow">PluralBridge application proof</p>
+          <h1 id="app-title">Explore the PluralBridge read-only demo</h1>
+          <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
+          <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
 
-      <form id="loginForm" class="login-panel">
-        <div class="field-row">
-          <label for="username">Username</label>
-          <input id="username" name="username" autocomplete="username" value="demo.user">
-        </div>
-        <div class="field-row">
-          <label for="password">Password</label>
-          <input id="password" name="password" type="password" autocomplete="current-password" value="pluralbridge-demo">
-        </div>
-        <div class="button-row" aria-label="Session contract actions">
-          <button type="submit" data-session-action="login">login</button>
-          <button type="button" data-session-action="loginFailure">login failure</button>
-          <button type="button" data-session-action="session">session</button>
-          <button type="button" data-session-action="systemMapping">system mapping</button>
-          <button type="button" data-session-action="logout">logout</button>
-        </div>
-      </form>
+          <form id="loginForm" class="login-panel">
+              <div class="session-summary">
+                  <strong>Protected demo session</strong>
+                  <span id="sessionStatus">You are signed in to the read-only PluralBridge demo.</span>
+              </div>
+              <div class="button-row" aria-label="Session actions">
+                  <button type="button" data-session-action="logout">logout</button>
+              </div>
+          </form>
+          <div class="button-row" aria-label="Read-only database actions">
+              <button type="button" data-contract="me">me</button>
+              <button type="button" data-contract="sourceSystems">source systems</button>
+              <button type="button" data-contract="importBatches">import batches</button>
+              <button type="button" data-contract="systems">systems</button>
+              <button type="button" data-contract="members">members</button>
+              <button type="button" data-contract="privacyBuckets">privacy buckets</button>
+              <button type="button" data-contract="customFields">custom fields</button>
+              <button type="button" data-contract="frontHistory">front history</button>
+              <button type="button" data-contract="sourceRecords">source records</button>
+              <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
+              <button type="button" data-contract="importMetadata">import metadata</button>
+          </div>
 
-      <div id="sessionStatus" class="session-status">Session: signed out</div>
-
-      <div class="button-row" aria-label="Read-only database actions">
-        <button type="button" data-contract="me">me</button>
-        <button type="button" data-contract="sourceSystems">source systems</button>
-        <button type="button" data-contract="importBatches">import batches</button>
-        <button type="button" data-contract="systems">systems</button>
-        <button type="button" data-contract="members">members</button>
-        <button type="button" data-contract="privacyBuckets">privacy buckets</button>
-        <button type="button" data-contract="customFields">custom fields</button>
-        <button type="button" data-contract="frontHistory">front history</button>
-        <button type="button" data-contract="sourceRecords">source records</button>
-        <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
-        <button type="button" data-contract="importMetadata">import metadata</button>
-      </div>
-
-      <pre id="appOutput" class="output-box" aria-live="polite">{ }</pre>
-    </section>
+          <div id="appOutput" class="output-box" aria-live="polite">{ }</div>
+      </section>
   </main>
 
   <script src="./app.js"></script>

--- a/app/app.css
+++ b/app/app.css
@@ -100,6 +100,31 @@ button[aria-pressed="true"] {
   background: rgba(15, 23, 42, 0.28);
 }
 
+.login-panel {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.session-summary {
+	display: grid;
+	gap: 0.25rem;
+}
+
+	.session-summary strong {
+		color: #f4f7fb;
+	}
+
+	.session-summary span {
+		color: #d8e1ed;
+	}
+
+.login-panel .button-row {
+	margin: 0;
+}
+
 .field-row {
   display: grid;
   gap: 0.35rem;
@@ -129,4 +154,229 @@ button[aria-pressed="true"] {
   font-weight: 700;
   color: #dbeafe;
   background: rgba(30, 64, 175, 0.28);
+}
+
+.json-output {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.output-heading {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+
+.output-note {
+  margin: 0 0 1rem;
+  color: #cbd5e1;
+}
+
+.member-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.member-card {
+  border: 1px solid rgba(168, 199, 255, 0.28);
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.member-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+}
+
+.member-name {
+  font-weight: 800;
+}
+
+.member-pronouns {
+  color: #a8c7ff;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.member-body {
+  padding: 0 1rem 1rem;
+}
+
+.member-toggle-row {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.member-toggle-button {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.member-content {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 0.75rem;
+}
+
+.member-description {
+  margin: 0;
+}
+
+.member-json {
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.85rem;
+  border-radius: 0.65rem;
+  background: #070a0d;
+}
+
+.me-fields {
+	display: grid;
+	gap: 0.65rem;
+	margin-bottom: 1rem;
+}
+
+.me-field {
+	display: grid;
+	grid-template-columns: 10rem minmax(0, 1fr);
+	gap: 0.75rem;
+}
+
+.me-label,
+.me-count-label {
+	color: #a8c7ff;
+	font-size: 0.85rem;
+	font-weight: 700;
+}
+
+.me-value {
+	color: #f4f7fb;
+	overflow-wrap: anywhere;
+}
+
+.me-section-heading {
+	margin: 1rem 0 0.75rem;
+	font-size: 1rem;
+}
+
+.me-count-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.me-count {
+	padding: 0.85rem;
+	border: 1px solid rgba(168, 199, 255, 0.22);
+	border-radius: 0.75rem;
+	background: rgba(7, 10, 13, 0.42);
+}
+
+.me-count-value {
+	display: block;
+	color: #f4f7fb;
+	font-size: 1.35rem;
+	font-weight: 800;
+}
+
+.me-json-details summary {
+	cursor: pointer;
+	color: #a8c7ff;
+	font-weight: 700;
+}
+
+.member-summary {
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
+	.member-summary::marker {
+		content: "";
+	}
+
+	.member-summary::-webkit-details-marker {
+		display: none;
+	}
+
+.member-identity {
+	display: grid;
+	gap: 0.2rem;
+}
+
+.member-pronouns {
+	justify-self: start;
+}
+
+.member-chevron {
+	align-self: center;
+	color: #a8c7ff;
+	font-weight: 900;
+	transition: transform 0.15s ease;
+}
+
+.member-card[open] .member-chevron {
+	transform: rotate(180deg);
+}
+
+.front-history-list {
+	display: grid;
+	gap: 0.75rem;
+}
+
+.front-history-card {
+	border: 1px solid rgba(168, 199, 255, 0.28);
+	border-radius: 0.85rem;
+	background: rgba(15, 23, 42, 0.55);
+}
+
+.front-history-summary {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto auto;
+	gap: 1rem;
+	align-items: center;
+	padding: 0.9rem 1rem;
+	cursor: pointer;
+}
+
+	.front-history-summary::marker {
+		content: "";
+	}
+
+	.front-history-summary::-webkit-details-marker {
+		display: none;
+	}
+
+.front-history-name {
+	font-weight: 800;
+}
+
+.front-history-time {
+	color: #a8c7ff;
+	font-size: 0.9rem;
+	font-weight: 700;
+	text-align: right;
+}
+
+.front-history-chevron {
+	align-self: center;
+	color: #a8c7ff;
+	font-weight: 900;
+	transition: transform 0.15s ease;
+}
+
+.front-history-card[open] .front-history-chevron {
+	transform: rotate(180deg);
+}
+
+.front-history-json {
+	max-height: 18rem;
+	overflow: auto;
+	margin: 0 1rem 1rem;
+	padding: 0.85rem;
+	border-radius: 0.65rem;
+	background: #070a0d;
 }

--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,4 @@
-const apiBaseUrl = "https://localhost:7275";
+﻿const apiBaseUrl = "https://localhost:7275";
 
 let selectedSystemId = null;
 
@@ -45,12 +45,1378 @@ const endpointBuilders = {
 };
 
 function updateSessionStatus() {
-  sessionStatus.textContent = "Phase 2B: read-only database surface";
+    sessionStatus.textContent = "You are signed in to the read-only PluralBridge demo.";
+}
+
+function clearOutput() {
+    output.replaceChildren();
 }
 
 function renderPayload(payload) {
-  output.textContent = JSON.stringify(payload, null, 2);
-  updateSessionStatus();
+    clearOutput();
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    output.appendChild(jsonBlock);
+    updateSessionStatus();
+}
+
+function getSourceSystemsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceSystems)) {
+        return payload.sourceSystems;
+    }
+
+    return [];
+}
+
+function getSourceSystemDisplayName(sourceSystem) {
+    if (sourceSystem && sourceSystem.displayName) {
+        return sourceSystem.displayName;
+    }
+
+    if (sourceSystem && sourceSystem.sourceSystemCode) {
+        return sourceSystem.sourceSystemCode;
+    }
+
+    return "(unnamed source system)";
+}
+
+function getSourceSystemCode(sourceSystem) {
+    return sourceSystem && sourceSystem.sourceSystemCode ? sourceSystem.sourceSystemCode : "";
+}
+
+function createSourceSystemAccordion(sourceSystem) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceSystemDisplayName(sourceSystem);
+
+    const code = document.createElement("span");
+    code.className = "member-pronouns";
+    code.textContent = getSourceSystemCode(sourceSystem);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(code);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(sourceSystem, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceSystems(payload) {
+    clearOutput();
+
+    const sourceSystems = getSourceSystemsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source systems";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceSystems.length + " source systems returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceSystems.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source systems were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceSystems.forEach(function (sourceSystem) {
+            wrapper.appendChild(createSourceSystemAccordion(sourceSystem));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSystemsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.systems)) {
+        return payload.systems;
+    }
+
+    return [];
+}
+
+function getSystemDisplayName(system) {
+    if (system && system.systemName) {
+        return system.systemName;
+    }
+
+    return "(unnamed system)";
+}
+
+function getSystemSubtitle(system) {
+    if (system && system.description) {
+        return system.description;
+    }
+
+    if (system && system.systemId) {
+        return system.systemId;
+    }
+
+    return "";
+}
+
+function createSystemAccordion(system) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSystemDisplayName(system);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSystemSubtitle(system);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(system, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSystems(payload) {
+    clearOutput();
+
+    const systems = getSystemsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Systems";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = systems.length + " systems returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (systems.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No systems were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        systems.forEach(function (system) {
+            wrapper.appendChild(createSystemAccordion(system));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function createMeField(labelText, valueText) {
+    const item = document.createElement("div");
+    item.className = "me-field";
+
+    const label = document.createElement("span");
+    label.className = "me-label";
+    label.textContent = labelText;
+
+    const value = document.createElement("span");
+    value.className = "me-value";
+    value.textContent = valueText || "(none)";
+
+    item.appendChild(label);
+    item.appendChild(value);
+
+    return item;
+}
+
+function createMeCount(labelText, valueText) {
+    const item = document.createElement("div");
+    item.className = "me-count";
+
+    const value = document.createElement("span");
+    value.className = "me-count-value";
+    value.textContent = String(valueText);
+
+    const label = document.createElement("span");
+    label.className = "me-count-label";
+    label.textContent = labelText;
+
+    item.appendChild(value);
+    item.appendChild(label);
+
+    return item;
+}
+
+function renderMe(payload) {
+    clearOutput();
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Demo session";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = "Read-only PluralBridge proof context for the protected demo session.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    const details = document.createElement("details");
+    details.className = "member-card";
+    details.open = true;
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = payload && payload.mode ? payload.mode : "read-only proof";
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = payload && payload.database ? payload.database : "";
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const fields = document.createElement("div");
+    fields.className = "me-fields";
+
+    fields.appendChild(createMeField("API", payload && payload.api ? payload.api : ""));
+    fields.appendChild(createMeField("Phase", payload && payload.phase ? payload.phase : ""));
+    fields.appendChild(createMeField("Write access", payload && payload.canWrite ? "enabled" : "disabled"));
+
+    if (payload && payload.proofSystem) {
+        fields.appendChild(createMeField("Proof system ID", payload.proofSystem.systemId || ""));
+        fields.appendChild(createMeField("Proof system name", payload.proofSystem.systemName || "(unnamed system)"));
+    }
+
+    body.appendChild(fields);
+
+    const countsHeading = document.createElement("h3");
+    countsHeading.className = "me-section-heading";
+    countsHeading.textContent = "Read-only record counts";
+    body.appendChild(countsHeading);
+
+    const countsGrid = document.createElement("div");
+    countsGrid.className = "me-count-grid";
+
+    if (payload && payload.counts) {
+        Object.keys(payload.counts).forEach(function (key) {
+            countsGrid.appendChild(createMeCount(key, payload.counts[key]));
+        });
+    }
+
+    body.appendChild(countsGrid);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    const jsonDetails = document.createElement("details");
+    jsonDetails.className = "me-json-details";
+
+    const jsonSummary = document.createElement("summary");
+    jsonSummary.textContent = "Raw JSON";
+
+    jsonDetails.appendChild(jsonSummary);
+    jsonDetails.appendChild(jsonBlock);
+    body.appendChild(jsonDetails);
+
+    details.appendChild(body);
+    wrapper.appendChild(details);
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getPrivacyBucketsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.privacyBuckets)) {
+        return payload.privacyBuckets;
+    }
+
+    return [];
+}
+
+function getPrivacyBucketName(bucket) {
+    return bucket && bucket.bucketName ? bucket.bucketName : "(unnamed privacy bucket)";
+}
+
+function getPrivacyBucketSubtitle(bucket) {
+    if (bucket && bucket.description) {
+        return bucket.description;
+    }
+
+    if (bucket && bucket.privacyBucketId) {
+        return bucket.privacyBucketId;
+    }
+
+    return "";
+}
+
+function createPrivacyBucketAccordion(bucket) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getPrivacyBucketName(bucket);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getPrivacyBucketSubtitle(bucket);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(bucket, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderPrivacyBuckets(payload) {
+    clearOutput();
+
+    const privacyBuckets = getPrivacyBucketsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Privacy buckets";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = privacyBuckets.length + " privacy buckets returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (privacyBuckets.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No privacy buckets were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        privacyBuckets.forEach(function (bucket) {
+            wrapper.appendChild(createPrivacyBucketAccordion(bucket));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getCustomFieldsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.customFields)) {
+        return payload.customFields;
+    }
+
+    return [];
+}
+
+function getCustomFieldName(customField) {
+    return customField && customField.fieldName ? customField.fieldName : "(unnamed custom field)";
+}
+
+function getCustomFieldSubtitle(customField) {
+    if (customField && customField.description) {
+        return customField.description;
+    }
+
+    if (customField && customField.fieldTypeCode !== null && customField.fieldTypeCode !== undefined) {
+        return "Field type code " + customField.fieldTypeCode;
+    }
+
+    if (customField && customField.customFieldId) {
+        return customField.customFieldId;
+    }
+
+    return "";
+}
+
+function createCustomFieldAccordion(customField) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getCustomFieldName(customField);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getCustomFieldSubtitle(customField);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(customField, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderCustomFields(payload) {
+    clearOutput();
+
+    const customFields = getCustomFieldsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Custom fields";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = customFields.length + " custom fields returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (customFields.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No custom fields were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        customFields.forEach(function (customField) {
+            wrapper.appendChild(createCustomFieldAccordion(customField));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getImportBatchesFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.importBatches)) {
+        return payload.importBatches;
+    }
+
+    return [];
+}
+
+function getImportBatchName(importBatch) {
+    if (importBatch && importBatch.sourceExportName) {
+        return importBatch.sourceExportName;
+    }
+
+    if (importBatch && importBatch.importToolName) {
+        return importBatch.importToolName;
+    }
+
+    if (importBatch && importBatch.importBatchId) {
+        return importBatch.importBatchId;
+    }
+
+    return "(unnamed import batch)";
+}
+
+function formatImportBatchTime(value) {
+    if (!value) {
+        return "";
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString();
+}
+
+function getImportBatchSubtitle(importBatch) {
+    if (!importBatch) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (importBatch.sourceSystemCode) {
+        parts.push(importBatch.sourceSystemCode);
+    }
+
+    if (importBatch.importCompletedAtUtc) {
+        parts.push("completed " + formatImportBatchTime(importBatch.importCompletedAtUtc));
+    } else if (importBatch.importStartedAtUtc) {
+        parts.push("started " + formatImportBatchTime(importBatch.importStartedAtUtc));
+    }
+
+    return parts.join(" · ");
+}
+
+function createImportBatchAccordion(importBatch) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getImportBatchName(importBatch);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getImportBatchSubtitle(importBatch);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(importBatch, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderImportBatches(payload) {
+    clearOutput();
+
+    const importBatches = getImportBatchesFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Import batches";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = importBatches.length + " import batches returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (importBatches.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No import batches were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        importBatches.forEach(function (importBatch) {
+            wrapper.appendChild(createImportBatchAccordion(importBatch));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSourceRecordsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceRecords)) {
+        return payload.sourceRecords;
+    }
+
+    return [];
+}
+
+function getSourceRecordName(sourceRecord) {
+    if (!sourceRecord) {
+        return "(unknown source record)";
+    }
+
+    if (sourceRecord.sourceEntityTypeCode && sourceRecord.sourceId) {
+        return sourceRecord.sourceEntityTypeCode + " · " + sourceRecord.sourceId;
+    }
+
+    if (sourceRecord.sourceEntityTypeCode) {
+        return sourceRecord.sourceEntityTypeCode;
+    }
+
+    if (sourceRecord.sourceRecordId) {
+        return sourceRecord.sourceRecordId;
+    }
+
+    return "(unknown source record)";
+}
+
+function getSourceRecordSubtitle(sourceRecord) {
+    if (!sourceRecord) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (sourceRecord.sourceSystemCode) {
+        parts.push(sourceRecord.sourceSystemCode);
+    }
+
+    if (sourceRecord.sourceEndpoint) {
+        parts.push(sourceRecord.sourceEndpoint);
+    }
+
+    return parts.join(" · ");
+}
+
+function createSourceRecordAccordion(sourceRecord) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceRecordName(sourceRecord);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSourceRecordSubtitle(sourceRecord);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(sourceRecord, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceRecords(payload) {
+    clearOutput();
+
+    const sourceRecords = getSourceRecordsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source records";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceRecords.length + " source records returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceRecords.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source records were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceRecords.forEach(function (sourceRecord) {
+            wrapper.appendChild(createSourceRecordAccordion(sourceRecord));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getSourceIdMappingsFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.sourceIdMappings)) {
+        return payload.sourceIdMappings;
+    }
+
+    return [];
+}
+
+function getSourceIdMappingName(mapping) {
+    if (!mapping) {
+        return "(unknown source ID mapping)";
+    }
+
+    if (mapping.sourceEntityTypeCode && mapping.sourceId) {
+        return mapping.sourceEntityTypeCode + " · " + mapping.sourceId;
+    }
+
+    if (mapping.sourceEntityTypeCode) {
+        return mapping.sourceEntityTypeCode;
+    }
+
+    if (mapping.sourceIdMapId) {
+        return mapping.sourceIdMapId;
+    }
+
+    return "(unknown source ID mapping)";
+}
+
+function getSourceIdMappingSubtitle(mapping) {
+    if (!mapping) {
+        return "";
+    }
+
+    const parts = [];
+
+    if (mapping.sourceSystemCode) {
+        parts.push(mapping.sourceSystemCode);
+    }
+
+    if (mapping.pluralBridgeEntityTypeCode && mapping.pluralBridgeId) {
+        parts.push(mapping.pluralBridgeEntityTypeCode + " → " + mapping.pluralBridgeId);
+    } else if (mapping.pluralBridgeEntityTypeCode) {
+        parts.push(mapping.pluralBridgeEntityTypeCode);
+    } else if (mapping.pluralBridgeId) {
+        parts.push(mapping.pluralBridgeId);
+    }
+
+    return parts.join(" · ");
+}
+
+function createSourceIdMappingAccordion(mapping) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getSourceIdMappingName(mapping);
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = getSourceIdMappingSubtitle(mapping);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(mapping, null, 2);
+
+    content.appendChild(jsonBlock);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    return details;
+}
+
+function renderSourceIdMappings(payload) {
+    clearOutput();
+
+    const sourceIdMappings = getSourceIdMappingsFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Source ID mappings";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = sourceIdMappings.length + " source ID mappings returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (sourceIdMappings.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No source ID mappings were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        sourceIdMappings.forEach(function (mapping) {
+            wrapper.appendChild(createSourceIdMappingAccordion(mapping));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function renderImportMetadata(payload) {
+    clearOutput();
+
+    const metadata = payload && payload.importMetadata ? payload.importMetadata : {};
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Import metadata";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = "Read-only import health and lineage summary for this demo system.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    const details = document.createElement("details");
+    details.className = "member-card";
+    details.open = true;
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = "Import status";
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "member-pronouns";
+    subtitle.textContent = metadata.systemExists === true ? "system exists" : "system missing";
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(subtitle);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const fields = document.createElement("div");
+    fields.className = "me-fields";
+
+    fields.appendChild(createMeField("System ID", payload && payload.systemId ? payload.systemId : ""));
+    fields.appendChild(createMeField("System exists", metadata.systemExists === true ? "yes" : "no"));
+
+    body.appendChild(fields);
+
+    const countsHeading = document.createElement("h3");
+    countsHeading.className = "me-section-heading";
+    countsHeading.textContent = "Import ledger counts";
+    body.appendChild(countsHeading);
+
+    const countsGrid = document.createElement("div");
+    countsGrid.className = "me-count-grid";
+
+    countsGrid.appendChild(createMeCount("source systems", metadata.sourceSystemCount));
+    countsGrid.appendChild(createMeCount("import batches", metadata.importBatchCount));
+    countsGrid.appendChild(createMeCount("source records", metadata.sourceRecordCount));
+    countsGrid.appendChild(createMeCount("source ID mappings", metadata.sourceIdMappingCount));
+
+    body.appendChild(countsGrid);
+
+    if (metadata.latestImportBatch) {
+        const batchHeading = document.createElement("h3");
+        batchHeading.className = "me-section-heading";
+        batchHeading.textContent = "Latest import batch";
+        body.appendChild(batchHeading);
+
+        body.appendChild(createImportBatchAccordion(metadata.latestImportBatch));
+    }
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(payload, null, 2);
+
+    const jsonDetails = document.createElement("details");
+    jsonDetails.className = "me-json-details";
+
+    const jsonSummary = document.createElement("summary");
+    jsonSummary.textContent = "Raw JSON";
+
+    jsonDetails.appendChild(jsonSummary);
+    jsonDetails.appendChild(jsonBlock);
+    body.appendChild(jsonDetails);
+
+    details.appendChild(body);
+    wrapper.appendChild(details);
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getMembersFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.members)) {
+        return payload.members;
+    }
+
+    return [];
+}
+
+function getMemberDisplayName(member) {
+    return member && member.displayName ? member.displayName : "(unnamed member)";
+}
+
+function getMemberPronouns(member) {
+    return member && member.pronouns ? member.pronouns : "";
+}
+
+function getMemberDescription(member) {
+    return member && member.description ? member.description : "No description available.";
+}
+
+function createMemberAccordion(member) {
+    const details = document.createElement("details");
+    details.className = "member-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "member-summary";
+
+    const identity = document.createElement("span");
+    identity.className = "member-identity";
+
+    const name = document.createElement("span");
+    name.className = "member-name";
+    name.textContent = getMemberDisplayName(member);
+
+    const pronouns = document.createElement("span");
+    pronouns.className = "member-pronouns";
+    pronouns.textContent = getMemberPronouns(member);
+
+    const chevron = document.createElement("span");
+    chevron.className = "member-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    identity.appendChild(name);
+    identity.appendChild(pronouns);
+
+    summary.appendChild(identity);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "member-body";
+
+    const toggleRow = document.createElement("div");
+    toggleRow.className = "member-toggle-row";
+    toggleRow.setAttribute("aria-label", "Member detail display mode");
+
+    const descriptionButton = document.createElement("button");
+    descriptionButton.type = "button";
+    descriptionButton.className = "member-toggle-button";
+    descriptionButton.textContent = "Description";
+
+    const jsonButton = document.createElement("button");
+    jsonButton.type = "button";
+    jsonButton.className = "member-toggle-button";
+    jsonButton.textContent = "JSON";
+
+    const content = document.createElement("div");
+    content.className = "member-content";
+
+    const descriptionText = document.createElement("p");
+    descriptionText.className = "member-description";
+    descriptionText.textContent = getMemberDescription(member);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "member-json json-output";
+    jsonBlock.textContent = JSON.stringify(member, null, 2);
+
+    function showDescription() {
+        descriptionButton.setAttribute("aria-pressed", "true");
+        jsonButton.setAttribute("aria-pressed", "false");
+        content.replaceChildren(descriptionText);
+    }
+
+    function showJson() {
+        descriptionButton.setAttribute("aria-pressed", "false");
+        jsonButton.setAttribute("aria-pressed", "true");
+        content.replaceChildren(jsonBlock);
+    }
+
+    descriptionButton.addEventListener("click", showDescription);
+    jsonButton.addEventListener("click", showJson);
+
+    toggleRow.appendChild(descriptionButton);
+    toggleRow.appendChild(jsonButton);
+
+    body.appendChild(toggleRow);
+    body.appendChild(content);
+    details.appendChild(body);
+
+    showDescription();
+
+    return details;
+}
+
+function renderMembers(payload) {
+    clearOutput();
+
+    const members = getMembersFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "member-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Members";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = members.length + " members returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (members.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No members were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        members.forEach(function (member) {
+            wrapper.appendChild(createMemberAccordion(member));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
+}
+
+function getFrontHistoryFromPayload(payload) {
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+
+    if (payload && Array.isArray(payload.frontHistory)) {
+        return payload.frontHistory;
+    }
+
+    return [];
+}
+
+function getFrontHistoryName(record) {
+    return record && record.memberDisplayName ? record.memberDisplayName : "(unknown member)";
+}
+
+function formatFrontHistoryTime(value) {
+    if (!value) {
+        return "";
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return "";
+    }
+
+    return date.toLocaleString();
+}
+
+function getFrontHistoryTimeRange(record) {
+    const start = formatFrontHistoryTime(record.startTimeMs);
+
+    if (record.isLive) {
+        return start ? start + " – Live" : "Live";
+    }
+
+    const end = formatFrontHistoryTime(record.endTimeMs);
+
+    if (start && end) {
+        return start + " – " + end;
+    }
+
+    if (start) {
+        return start;
+    }
+
+    return "No time recorded";
+}
+
+function createFrontHistoryAccordion(record) {
+    const details = document.createElement("details");
+    details.className = "front-history-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "front-history-summary";
+
+    const name = document.createElement("span");
+    name.className = "front-history-name";
+    name.textContent = getFrontHistoryName(record);
+
+    const timeRange = document.createElement("span");
+    timeRange.className = "front-history-time";
+    timeRange.textContent = getFrontHistoryTimeRange(record);
+
+    const chevron = document.createElement("span");
+    chevron.className = "front-history-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "v";
+
+    summary.appendChild(name);
+    summary.appendChild(timeRange);
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const jsonBlock = document.createElement("pre");
+    jsonBlock.className = "front-history-json json-output";
+    jsonBlock.textContent = JSON.stringify(record, null, 2);
+
+    details.appendChild(jsonBlock);
+
+    return details;
+}
+
+function renderFrontHistory(payload) {
+    clearOutput();
+
+    const records = getFrontHistoryFromPayload(payload);
+
+    const wrapper = document.createElement("section");
+    wrapper.className = "front-history-list";
+
+    const heading = document.createElement("h2");
+    heading.className = "output-heading";
+    heading.textContent = "Front History";
+
+    const note = document.createElement("p");
+    note.className = "output-note";
+    note.textContent = records.length + " front history records returned from the read-only demo API.";
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(note);
+
+    if (records.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "output-note";
+        empty.textContent = "No front history records were returned.";
+        wrapper.appendChild(empty);
+    } else {
+        records.forEach(function (record) {
+            wrapper.appendChild(createFrontHistoryAccordion(record));
+        });
+    }
+
+    output.appendChild(wrapper);
+    updateSessionStatus();
 }
 
 function apiUrl(endpoint) {
@@ -126,9 +1492,34 @@ async function renderContract(key) {
   });
 
   try {
-    const endpoint = await endpointBuilder();
-    const payload = await fetchJson(endpoint);
-    renderPayload(payload);
+      const endpoint = await endpointBuilder();
+      const payload = await fetchJson(endpoint);
+
+      if (key === "me") {
+          renderMe(payload);
+      } else if (key === "sourceSystems") {
+          renderSourceSystems(payload);
+      } else if (key === "importBatches") {
+          renderImportBatches(payload);
+      } else if (key === "systems") {
+          renderSystems(payload);
+      } else if (key === "privacyBuckets") {
+          renderPrivacyBuckets(payload);
+      } else if (key === "customFields") {
+          renderCustomFields(payload);
+      } else if (key === "members") {
+          renderMembers(payload);
+      } else if (key === "frontHistory") {
+          renderFrontHistory(payload);
+      } else if (key === "sourceRecords") {
+          renderSourceRecords(payload);
+      } else if (key === "sourceIdMappings") {
+          renderSourceIdMappings(payload);
+      } else if (key === "importMetadata") {
+          renderImportMetadata(payload);
+      } else {
+          renderPayload(payload);
+      }
   } catch (error) {
     renderPayload({
       phase: "Phase 2B",
@@ -151,6 +1542,30 @@ function renderFrozenSessionAction(action) {
   });
 }
 
+async function logout() {
+  try {
+    const response = await fetch("/logout", {
+      method: "POST",
+      credentials: "same-origin"
+    });
+
+    if (response.redirected) {
+      window.location.href = response.url;
+      return;
+    }
+
+    window.location.href = "/login";
+  } catch (error) {
+    renderPayload({
+      phase: "Phase 2B",
+      action: "logout",
+      canWrite: false,
+      error: error.name || "Error",
+      message: error.message
+    });
+  }
+}
+
 loginForm.addEventListener("submit", function(event) {
   event.preventDefault();
   renderFrozenSessionAction("login");
@@ -159,7 +1574,14 @@ loginForm.addEventListener("submit", function(event) {
 sessionButtons.forEach(function(button) {
   if (button.dataset.sessionAction !== "login") {
     button.addEventListener("click", function() {
-      renderFrozenSessionAction(button.dataset.sessionAction);
+      const action = button.dataset.sessionAction;
+
+      if (action === "logout") {
+        logout();
+        return;
+      }
+
+      renderFrozenSessionAction(action);
     });
   }
 });

--- a/app/index.html
+++ b/app/index.html
@@ -8,48 +8,37 @@
 </head>
 <body>
   <main class="app-shell" aria-labelledby="app-title">
-    <section class="app-card">
-      <p class="eyebrow">PluralBridge application proof</p>
-      <h1 id="app-title">Phase 2B: complete read-only database surface</h1>
-      <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
-      <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
+      <section class="app-card">
+          <p class="eyebrow">PluralBridge application proof</p>
+          <h1 id="app-title">Explore the PluralBridge read-only demo</h1>
+          <p>Real database-backed read-only responses from the Phase 2B C# REST API over the validated 1-6 proof slice.</p>
+          <p>No browser-side mock data, no write path, and no private raw source payload exposure.</p>
 
-      <form id="loginForm" class="login-panel">
-        <div class="field-row">
-          <label for="username">Username</label>
-          <input id="username" name="username" autocomplete="username" value="demo.user">
-        </div>
-        <div class="field-row">
-          <label for="password">Password</label>
-          <input id="password" name="password" type="password" autocomplete="current-password" value="pluralbridge-demo">
-        </div>
-        <div class="button-row" aria-label="Session contract actions">
-          <button type="submit" data-session-action="login">login</button>
-          <button type="button" data-session-action="loginFailure">login failure</button>
-          <button type="button" data-session-action="session">session</button>
-          <button type="button" data-session-action="systemMapping">system mapping</button>
-          <button type="button" data-session-action="logout">logout</button>
-        </div>
-      </form>
+          <form id="loginForm" class="login-panel">
+              <div class="session-summary">
+                  <strong>Protected demo session</strong>
+                  <span id="sessionStatus">You are signed in to the read-only PluralBridge demo.</span>
+              </div>
+              <div class="button-row" aria-label="Session actions">
+                  <button type="button" data-session-action="logout">logout</button>
+              </div>
+          </form>
+          <div class="button-row" aria-label="Read-only database actions">
+              <button type="button" data-contract="me">me</button>
+              <button type="button" data-contract="sourceSystems">source systems</button>
+              <button type="button" data-contract="importBatches">import batches</button>
+              <button type="button" data-contract="systems">systems</button>
+              <button type="button" data-contract="members">members</button>
+              <button type="button" data-contract="privacyBuckets">privacy buckets</button>
+              <button type="button" data-contract="customFields">custom fields</button>
+              <button type="button" data-contract="frontHistory">front history</button>
+              <button type="button" data-contract="sourceRecords">source records</button>
+              <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
+              <button type="button" data-contract="importMetadata">import metadata</button>
+          </div>
 
-      <div id="sessionStatus" class="session-status">Session: signed out</div>
-
-      <div class="button-row" aria-label="Read-only database actions">
-        <button type="button" data-contract="me">me</button>
-        <button type="button" data-contract="sourceSystems">source systems</button>
-        <button type="button" data-contract="importBatches">import batches</button>
-        <button type="button" data-contract="systems">systems</button>
-        <button type="button" data-contract="members">members</button>
-        <button type="button" data-contract="privacyBuckets">privacy buckets</button>
-        <button type="button" data-contract="customFields">custom fields</button>
-        <button type="button" data-contract="frontHistory">front history</button>
-        <button type="button" data-contract="sourceRecords">source records</button>
-        <button type="button" data-contract="sourceIdMappings">source ID mappings</button>
-        <button type="button" data-contract="importMetadata">import metadata</button>
-      </div>
-
-      <pre id="appOutput" class="output-box" aria-live="polite">{ }</pre>
-    </section>
+          <div id="appOutput" class="output-box" aria-live="polite">{ }</div>
+      </section>
   </main>
 
   <script src="./app.js"></script>


### PR DESCRIPTION
Promotes the v0.7.3 read-only demo UI polish release from dev to master.

This release replaces raw full-page JSON output with friendly cards and rows for every read-only demo endpoint, keeps raw JSON available behind expanders for proof and verification, replaces the in-app login proof panel with a compact protected-session strip, and updates the app title to “Explore the PluralBridge read-only demo.”

No API C# code, database code, connection strings, import/upload code, or Azure secrets are changed.