### PR TITLE
Add conference booth notice to website

### DIFF
--- a/api/PluralBridge.Api/PluralBridge.Api.sln
+++ b/api/PluralBridge.Api/PluralBridge.Api.sln
@@ -1,9 +1,41 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.37314.3 d17.14
+VisualStudioVersion = 17.14.37314.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralBridge.Api", "PluralBridge.Api\PluralBridge.Api.csproj", "{D40E659B-E483-405D-BD49-1EE1EBDE890C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Website", "Website", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\website\about.html = ..\..\website\about.html
+		..\..\website\developer-workflow.html = ..\..\website\developer-workflow.html
+		..\..\website\docs.html = ..\..\website\docs.html
+		..\..\website\export-now.html = ..\..\website\export-now.html
+		..\..\website\googleb087a67406285ba0.html = ..\..\website\googleb087a67406285ba0.html
+		..\..\website\help-me-export.html = ..\..\website\help-me-export.html
+		..\..\website\index.html = ..\..\website\index.html
+		..\..\website\install.html = ..\..\website\install.html
+		..\..\website\privacy-banner.js = ..\..\website\privacy-banner.js
+		..\..\website\robots.txt = ..\..\website\robots.txt
+		..\..\website\run.html = ..\..\website\run.html
+		..\..\website\safety.html = ..\..\website\safety.html
+		..\..\website\simply-plural-shutdown.html = ..\..\website\simply-plural-shutdown.html
+		..\..\website\site-menu.js = ..\..\website\site-menu.js
+		..\..\website\sitemap.xml = ..\..\website\sitemap.xml
+		..\..\website\start-here.html = ..\..\website\start-here.html
+		..\..\website\style.css = ..\..\website\style.css
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{CC619F1C-AF5F-4A27-AAB6-75BBFCE18148}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\website\docs\index.html = ..\..\website\docs\index.html
+		..\..\website\docs\index.md = ..\..\website\docs\index.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{7B6E8868-C9C0-4C68-BCC1-A667DAFDB7BE}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\website\images\background.jpg = ..\..\website\images\background.jpg
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,6 +50,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CC619F1C-AF5F-4A27-AAB6-75BBFCE18148} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{7B6E8868-C9C0-4C68-BCC1-A667DAFDB7BE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF5C65E4-340D-4E25-AC7D-DA2AA63CC3CC}

--- a/website/index.html
+++ b/website/index.html
@@ -105,6 +105,19 @@
     </section>
 
     <section class="section notice">
+        <h2>PluralBridge will be at the Power to the Plurals Conference</h2>
+        <p>
+            PluralBridge will have a virtual booth at the Power to the Plurals Conference. We will be sharing export
+            guidance, project documentation, screenshots, and demo resources for Systems working to preserve their
+            Simply Plural data before the July 1 shutdown.
+        </p>
+        <p>
+            Start with the export guide now, then visit the booth during the conference for questions and walkthroughs.
+        </p>
+        <p><a href="export-now.html">Open the export guide</a></p>
+    </section>
+
+    <section class="section notice">
         <h2>Export first. Refine later.</h2>
         <p>
             As currently announced, the Simply Plural servers are expected to shut down on July 1, 2026, with user data


### PR DESCRIPTION
## Summary

* Adds a homepage notice that PluralBridge will have a virtual booth at the Power to the Plurals Conference.
* Points visitors to the export guide for Simply Plural data preservation before the July 1 shutdown.
* Adds the static website files to the Visual Studio solution as solution items for easier editing.

## Scope

Website/public messaging and solution organization only.

No app, API, database, import, upload, or Azure behavior changes.
