### PR TITLE
Release v0.7.6 contact page

### DIFF
--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -6,6 +6,19 @@ Tags are listed in reverse chronological order so the latest project changes app
 
 ---
 
+## v0.7.6 — Contact page
+
+Static public website release adding a dedicated Contact page for project-level communication.
+
+- Added `website/contact.html`.
+- Replaced disabled `Contact Us` placeholders in the About menu with live `contact.html` links across static pages.
+- Added project-level contact paths:
+  - General contact: `info@thepluralbridge.org`
+  - Support/export help: `support@thepluralbridge.org`
+- Added privacy and safety boundaries telling visitors not to send Simply Plural tokens, passwords, export files, private System data, or screenshots with private data.
+- Added not-emergency-support language and an independent-project disclaimer.
+- Added `contact.html` to the website sitemap and VS solution website items.
+
 ## v0.7.5 — Conference website demo navigation polish
 
 - Added a Projects navigation menu between Guides and Community.

--- a/api/PluralBridge.Api/PluralBridge.Api.sln
+++ b/api/PluralBridge.Api/PluralBridge.Api.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Website", "Website", "{02EA
 	ProjectSection(SolutionItems) = preProject
 		..\..\website\about.html = ..\..\website\about.html
 		..\..\website\browser-app.html = ..\..\website\browser-app.html
+		..\..\website\contact.html = ..\..\website\contact.html
 		..\..\website\developer-workflow.html = ..\..\website\developer-workflow.html
 		..\..\website\docs.html = ..\..\website\docs.html
 		..\..\website\export-now.html = ..\..\website\export-now.html
@@ -36,6 +37,15 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{7B6E8868-C9C0-4C68-BCC1-A667DAFDB7BE}"
 	ProjectSection(SolutionItems) = preProject
 		..\..\website\images\background.jpg = ..\..\website\images\background.jpg
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\CONTRIBUTING.md = ..\..\CONTRIBUTING.md
+		..\..\LICENSE = ..\..\LICENSE
+		..\..\README.md = ..\..\README.md
+		..\..\SECURITY.md = ..\..\SECURITY.md
+		..\..\TAG_TASKS.md = ..\..\TAG_TASKS.md
 	EndProjectSection
 EndProject
 Global

--- a/website/browser-app.html
+++ b/website/browser-app.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="button demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/contact.html
+++ b/website/contact.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>About PluralBridge and Needs of the Many</title>
-    <meta name="description" content="About PluralBridge, Needs of the Many, and the project mission for Simply Plural data preservation and continuity.">
+    <title>Contact PluralBridge | PluralBridge</title>
+    <meta name="description" content="Contact PluralBridge for general questions, export help, and conference booth follow-up.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta property="og:title" content="About PluralBridge and Needs of the Many">
@@ -62,8 +62,8 @@
             <details class="nav-menu">
                 <summary data-current="section">About</summary>
                 <div class="nav-menu-panel">
-                    <a href="about.html" aria-current="page">About PluralBridge</a>
-                    <a href="contact.html">Contact Us</a>
+                    <a href="about.html">About PluralBridge</a>
+                    <a href="contact.html" aria-current="page">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>
@@ -79,64 +79,76 @@
 
 
 <main>
-    <section class="hero">
-        <p class="eyebrow">About the project</p>
-        <h1>PluralBridge is a preservation and continuity project.</h1>
-        <p class="lede">
-            PluralBridge began with a practical problem: plural Systems need a way to get their Simply Plural data out,
-            preserve it locally, and make that preserved data useful after the original service is gone.
-        </p>
-        <img class="about-logo" src="assets/images/pluralbridge-about-logo.jfif" alt="The PluralBridge logo showing a bridge over water with the text The PluralBridge.">
-        <div class="actions">
-            <a class="button primary" href="https://github.com/needsofmany/PluralBridge">View the repository</a>
-            <a class="button" href="safety.html">Read safety notes</a>
-        </div>
-    </section>
+        <section class="page-hero">
+            <p class="eyebrow">Contact</p>
+            <h1>Contact PluralBridge</h1>
+            <p>
+                PluralBridge is an independent project focused on helping Systems preserve, understand,
+                and eventually move their own Simply Plural data.
+            </p>
+        </section>
 
-    <section class="section">
-        <h2>The first job</h2>
-        <p>
-            The first job is export. Data that remains trapped inside a service scheduled for shutdown is data at risk.
-            PluralBridge focuses first on creating local files that users can keep, back up, inspect, and later feed into
-            database scripts, viewers, converters, importers, and continuity tools.
-        </p>
-    </section>
+        <section class="content-section">
+            <h2>General contact</h2>
+            <p>
+                For general questions about PluralBridge, the public website, project direction, or
+                conference follow-up, email
+                <a href="mailto:info@thepluralbridge.org">info@thepluralbridge.org</a>.
+            </p>
+        </section>
 
-    <section class="section">
-        <h2>The longer path</h2>
-        <p>
-            The current repository includes export work and SQL Server database migration work. Future layers may include
-            local viewers, SQLite support, cloud migration paths, compatible APIs where feasible, and clients for desktop,
-            web, and mobile use.
-        </p>
-    </section>
+        <section class="content-section">
+            <h2>Support / export help</h2>
+            <p>
+                For help with the public Simply Plural export guidance, email
+                <a href="mailto:support@thepluralbridge.org">support@thepluralbridge.org</a>.
+            </p>
+            <p>
+                Please describe where you are stuck in the export process. Keep private System details
+                out of the message.
+            </p>
+        </section>
 
-    <section class="section">
-        <h2>Needs of the Many</h2>
-        <p>
-            Needs of the Many is the public project identity behind PluralBridge. The name reflects the basic operating
-            principle: community-held data should have a path to preservation, continuity, and practical future use.
-        </p>
-    </section>
+        <section class="content-section">
+            <h2>Conference booth note</h2>
+            <p>
+                If you met PluralBridge through the Power to the Plurals Conference booth, these
+                project-level addresses are the safest way to follow up after the booth.
+            </p>
+        </section>
 
-    <section class="section notice">
-        <h2>Independent project boundary</h2>
-        <p>
-            PluralBridge is independent. It is not affiliated with Simply Plural or Apparyllis. The project is built as
-            free/open-source software under the GNU GPL v3.0 and is published for inspection, use, and contribution.
-        </p>
-    </section>
+        <section class="content-section warning-card">
+            <h2>Privacy reminder</h2>
+            <p>
+                Do not send Simply Plural tokens, passwords, export files, private System data, or
+                screenshots that contain private information.
+            </p>
+            <p>
+                PluralBridge is being built around privacy and data ownership. Public threads, email,
+                and direct messages are not safe places to share sensitive System data.
+            </p>
+        </section>
 
-    <section class="section">
-        <h2>Repository</h2>
-        <p>
-            Source code, documentation, database scripts, safety notes, and current project work are published here:
-        </p>
-        <p>
-            <a href="https://github.com/needsofmany/PluralBridge">https://github.com/needsofmany/PluralBridge</a>
-        </p>
-    </section>
-</main>
+        <section class="content-section warning-card">
+            <h2>Not emergency support</h2>
+            <p>
+                PluralBridge is not emergency support. Do not use PluralBridge contact addresses for
+                crisis, safety, medical, legal, or emergency requests.
+            </p>
+            <p>
+                If someone is in immediate danger, contact local emergency services or a crisis support
+                service in your area.
+            </p>
+        </section>
+
+        <section class="content-section">
+            <h2>Independent project disclaimer</h2>
+            <p>
+                PluralBridge is an independent project. It is not affiliated with Simply Plural,
+                Apparyllis, or the Simply Plural team.
+            </p>
+        </section>
+    </main>
 
 <footer class="site-footer">
     <div class="footer-inner">

--- a/website/developer-workflow.html
+++ b/website/developer-workflow.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/docs.html
+++ b/website/docs.html
@@ -51,7 +51,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/export-now.html
+++ b/website/export-now.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/help-me-export.html
+++ b/website/help-me-export.html
@@ -64,7 +64,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/index.html
+++ b/website/index.html
@@ -81,7 +81,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/install.html
+++ b/website/install.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/run.html
+++ b/website/run.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/safety.html
+++ b/website/safety.html
@@ -63,7 +63,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/simply-plural-shutdown.html
+++ b/website/simply-plural-shutdown.html
@@ -64,7 +64,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -18,4 +18,8 @@
     <url>
         <loc>https://thepluralbridge.org/simply-plural-shutdown.html</loc>
     </url>
+    <url>
+        <loc>https://thepluralbridge.org/contact.html</loc>
+        <lastmod>2026-06-12</lastmod>
+    </url>
 </urlset>

--- a/website/start-here.html
+++ b/website/start-here.html
@@ -64,7 +64,7 @@
                 <summary>About</summary>
                 <div class="nav-menu-panel">
                     <a href="about.html">About PluralBridge</a>
-                    <span class="nav-menu-disabled">Contact Us <span class="nav-menu-note">coming soon</span></span>
+                    <a href="contact.html">Contact Us</a>
                 </div>
             </details>
             <a class="nav-demo-button" href="https://demo.thepluralbridge.org/app/">Demo</a>


### PR DESCRIPTION
Promotes the v0.7.6 Contact page release from dev to master.

Changes included:

* Adds `website/contact.html`.
* Enables the About menu Contact Us item across static website pages.
* Adds project-level contact addresses:

  * `info@thepluralbridge.org`
  * `support@thepluralbridge.org`
* Adds privacy and safety boundaries telling visitors not to send Simply Plural tokens, passwords, export files, private System data, or screenshots with private data.
* Adds not-emergency-support language.
* Adds the independent project disclaimer.
* Adds `contact.html` to `website/sitemap.xml`.
* Adds `contact.html` and root project files to the VS2022 solution items for easier editing.
* Updates `TAG_TASKS.md` with the v0.7.6 release note.

App, API, database, import, upload, Azure runtime behavior, demo auth, and demo data remain unchanged.
