### PR TITLE
Add PB-NEXT Chapter 2 safe-spine SQL foundation

### DIFF
--- a/TAG_TASKS.md
+++ b/TAG_TASKS.md
@@ -6,6 +6,56 @@ Tags are listed in reverse chronological order so the latest project changes app
 
 ---
 
+## v0.8.0 — PB-NEXT Chapter 2 safe-spine SQL foundation
+
+### Major tasks completed
+
+* Added Chapter 2 safe-spine SQL scripts under `scripts/sqlserver/chap2_safe_spine/scripts/`.
+* Confirmed frozen demo behavior before safe-spine work:
+
+  * demo login still works
+  * `/api/me` still works
+  * existing read-only demo counts remain unchanged
+* Confirmed current runtime schema contract around:
+
+  * `pb_systems`
+  * `pb_members`
+  * `pb_front_history`
+  * `pb_privacy_buckets`
+  * `pb_custom_fields`
+* Added account lifecycle foundation:
+
+  * `pb_account_statuses`
+  * `pb_accounts`
+  * demo account seed scripts
+* Added constrained role and membership lifecycle lookups:
+
+  * `pb_roles`
+  * `pb_system_membership_statuses`
+* Added system membership foundation:
+
+  * `pb_system_memberships`
+  * `pb_system_membership_roles`
+* Corrected membership-role design to support multiple roles per system membership by moving role assignment into `pb_system_membership_roles`.
+* Added foreign key coverage for:
+
+  * account status
+  * account membership
+  * system membership
+  * membership status
+  * membership role assignment
+* Added composite primary key on `pb_system_membership_roles` to prevent duplicate role assignments for the same membership.
+* Seeded the demo account.
+* Seeded the demo account’s active Owner membership on the existing demo system.
+
+### Notes
+
+* This tag is SQL/script foundation work only.
+* Runtime authorization behavior is not changed yet.
+* Existing demo read-only behavior remains the baseline.
+* The Simply Plural-shaped privacy bucket data remains untouched.
+* PB-native visibility scope, account resolver, membership resolver, authorization boundary, and diagnostic tracing remain future Chapter 2 tasks.
+
 ## v0.7.6 — Contact page
 
 Static public website release adding a dedicated Contact page for project-level communication.

--- a/scripts/sqlserver/chap2_safe_spine/scripts/PD-NEXT-DOCS.txt
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/PD-NEXT-DOCS.txt
@@ -1,0 +1,29 @@
+1. PB-NEXT-ACCOUNT-001
+   Account Lifecycle And System Membership Implementation Plan
+
+2. PB-NEXT-AUTHZ-SHELL-001
+   Central Authorization Decision Shell Implementation Plan
+
+3. PB-NEXT-RELATIONSHIP-001
+   Relationship Authority Model Implementation Plan
+
+4. PB-NEXT-CONSENT-SCHEMA-001
+   Consent Record Schema And Lifecycle Implementation Plan
+
+5. PB-NEXT-AUDIT-SCHEMA-001
+   Payload-Free Audit Event Schema Implementation Plan
+
+6. PB-NEXT-IMPORT-LEDGER-001
+   Import Batch, Job Ledger, Source Record, And Source ID Map Implementation Plan
+
+7. PB-NEXT-UPLOAD-INTAKE-001
+   Upload Intake, Quarantine, Retention, And Purge Implementation Plan
+
+8. PB-NEXT-DRYRUN-001
+   Validation And Dry Run Import Plan
+
+9. PB-NEXT-ALPHA-COMMIT-001
+   Smallest Safe Alpha Commit Plan
+
+10. PB-NEXT-IMPLEMENTATION-QUEUE-001
+   Final ordered task queue for actual implementation branches

--- a/scripts/sqlserver/chap2_safe_spine/scripts/The phase we just completed was.txt
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/The phase we just completed was.txt
@@ -1,0 +1,19 @@
+The phase we just completed was:
+
+PB-NEXT Foundation Planning Pass
+
+It produced and merged the foundation docs plus the gate:
+
+BLUEPRINT_CROSSWALK.md
+PB-NEXT-DATA-001.md
+PB-NEXT-USER-001.md
+PB-NEXT-AUTHZ-001.md
+PB-NEXT-REB-001.md
+PB-NEXT-CONSENT-001.md
+PB-NEXT-AUDIT-001.md
+PB-NEXT-IMPORT-001.md
+PB-NEXT-GATE-001.md
+
+The next phase should be named:
+
+PB-NEXT Implementation Gate Planning

--- a/scripts/sqlserver/chap2_safe_spine/scripts/add_membership_status_id_fk_to_pb_system_memberships.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/add_membership_status_id_fk_to_pb_system_memberships.sql
@@ -1,0 +1,66 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_memberships', N'U') IS NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_system_memberships does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_membership_statuses', N'U') IS NULL
+BEGIN
+    THROW 50002, 'Stop: dbo.pb_system_membership_statuses does not exist.', 1;
+END;
+GO
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships sm
+    LEFT JOIN dbo.pb_system_membership_statuses ms
+        ON ms.MembershipStatusId = sm.MembershipStatusId
+    WHERE ms.MembershipStatusId IS NULL
+)
+BEGIN
+    THROW 50003, 'Stop: dbo.pb_system_memberships contains MembershipStatusId values with no matching lookup row.', 1;
+END;
+GO
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.foreign_keys
+    WHERE name = N'FK_pb_system_memberships_pb_system_membership_statuses'
+      AND parent_object_id = OBJECT_ID(N'dbo.pb_system_memberships')
+)
+BEGIN
+    ALTER TABLE dbo.pb_system_memberships
+        ADD CONSTRAINT FK_pb_system_memberships_pb_system_membership_statuses
+        FOREIGN KEY (MembershipStatusId)
+        REFERENCES dbo.pb_system_membership_statuses (MembershipStatusId);
+END;
+GO
+
+SELECT
+    fk.name AS ForeignKeyName,
+    OBJECT_NAME(fk.parent_object_id) AS ParentTable,
+    pc.name AS ParentColumn,
+    OBJECT_NAME(fk.referenced_object_id) AS ReferencedTable,
+    rc.name AS ReferencedColumn
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc
+    ON fkc.constraint_object_id = fk.object_id
+JOIN sys.columns pc
+    ON pc.object_id = fkc.parent_object_id
+   AND pc.column_id = fkc.parent_column_id
+JOIN sys.columns rc
+    ON rc.object_id = fkc.referenced_object_id
+   AND rc.column_id = fkc.referenced_column_id
+WHERE fk.name = N'FK_pb_system_memberships_pb_system_membership_statuses';
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_and_populate_pb_roles.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_and_populate_pb_roles.sql
@@ -1,0 +1,69 @@
+CREATE TABLE dbo.pb_roles
+(
+    RoleId       int            NOT NULL,
+    RoleName     nvarchar(64)   NOT NULL,
+    RoleDesc     nvarchar(500)  NOT NULL,
+    DisplayOrder int            NOT NULL,
+    IsActive     bit            NOT NULL CONSTRAINT DF_pb_roles_IsActive DEFAULT (1),
+
+    CONSTRAINT PK_pb_roles PRIMARY KEY (RoleId),
+    CONSTRAINT UQ_pb_roles_RoleName UNIQUE (RoleName),
+    CONSTRAINT CK_pb_roles_DisplayOrder_Positive CHECK (DisplayOrder > 0)
+);
+GO
+
+INSERT INTO dbo.pb_roles
+(
+    RoleId,
+    RoleName,
+    RoleDesc,
+    DisplayOrder,
+    IsActive
+)
+VALUES
+(
+    1,
+    N'Owner',
+    N'Full control of the system, including membership management and system-level settings.',
+    10,
+    1
+),
+(
+    2,
+    N'Admin',
+    N'Can manage system data and most settings, but does not outrank the owner.',
+    20,
+    1
+),
+(
+    3,
+    N'Editor',
+    N'Can add and edit day-to-day system data such as members, fronting records, group notes, and avatars where allowed.',
+    30,
+    1
+),
+(
+    4,
+    N'Viewer',
+    N'Can read system data allowed by privacy rules, with no edit rights.',
+    40,
+    1
+),
+(
+    5,
+    N'LimitedViewer',
+    N'Can read only explicitly shared or privacy-filtered data.',
+    50,
+    1
+);
+GO
+
+SELECT
+    RoleId,
+    RoleName,
+    RoleDesc,
+    DisplayOrder,
+    IsActive
+FROM dbo.pb_roles
+ORDER BY DisplayOrder;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_account_statuses.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_account_statuses.sql
@@ -1,0 +1,90 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_account_statuses', N'U') IS NOT NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_account_statuses already exists.', 1;
+END;
+GO
+
+CREATE TABLE dbo.pb_account_statuses
+(
+    AccountStatusId int NOT NULL,
+    StatusName nvarchar(64) NOT NULL,
+    StatusDesc nvarchar(500) NOT NULL,
+    DisplayOrder int NOT NULL,
+    IsActive bit NOT NULL
+        CONSTRAINT DF_pb_account_statuses_IsActive DEFAULT (1),
+
+    CONSTRAINT PK_pb_account_statuses
+        PRIMARY KEY CLUSTERED (AccountStatusId),
+
+    CONSTRAINT UQ_pb_account_statuses_StatusName
+        UNIQUE (StatusName),
+
+    CONSTRAINT CK_pb_account_statuses_DisplayOrder_Positive
+        CHECK (DisplayOrder > 0)
+);
+GO
+
+INSERT INTO dbo.pb_account_statuses
+(
+    AccountStatusId,
+    StatusName,
+    StatusDesc,
+    DisplayOrder,
+    IsActive
+)
+VALUES
+(
+    1,
+    N'Active',
+    N'Account is active and may authenticate and use granted system memberships.',
+    10,
+    1
+),
+(
+    2,
+    N'PendingEmailVerification',
+    N'Account has been created, but email verification has not been completed yet.',
+    20,
+    1
+),
+(
+    3,
+    N'Disabled',
+    N'Account is administratively disabled and cannot authenticate or access systems.',
+    30,
+    1
+),
+(
+    4,
+    N'Locked',
+    N'Account is temporarily locked due to security, risk, or administrative action.',
+    40,
+    1
+),
+(
+    5,
+    N'Deleted',
+    N'Account has been marked deleted and is no longer available for authentication or membership access.',
+    50,
+    1
+);
+GO
+
+SELECT
+    AccountStatusId,
+    StatusName,
+    StatusDesc,
+    DisplayOrder,
+    IsActive
+FROM dbo.pb_account_statuses
+ORDER BY DisplayOrder;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_accounts.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_accounts.sql
@@ -1,0 +1,84 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_account_statuses', N'U') IS NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_account_statuses does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_accounts', N'U') IS NOT NULL
+BEGIN
+    THROW 50002, 'Stop: dbo.pb_accounts already exists.', 1;
+END;
+GO
+
+CREATE TABLE dbo.pb_accounts
+(
+    AccountId uniqueidentifier NOT NULL
+        CONSTRAINT DF_pb_accounts_AccountId DEFAULT newsequentialid(),
+
+    Email nvarchar(320) NOT NULL,
+    DisplayName nvarchar(255) NULL,
+    AccountStatusId int NOT NULL,
+
+    CreatedAtUtc datetime2(3) NOT NULL
+        CONSTRAINT DF_pb_accounts_CreatedAtUtc DEFAULT sysutcdatetime(),
+
+    UpdatedAtUtc datetime2(3) NULL,
+
+    CONSTRAINT PK_pb_accounts
+        PRIMARY KEY CLUSTERED (AccountId),
+
+    CONSTRAINT UQ_pb_accounts_Email
+        UNIQUE (Email),
+
+    CONSTRAINT FK_pb_accounts_pb_account_statuses
+        FOREIGN KEY (AccountStatusId)
+        REFERENCES dbo.pb_account_statuses (AccountStatusId),
+
+    CONSTRAINT CK_pb_accounts_Email_NotBlank
+        CHECK (len(ltrim(rtrim(Email))) > 0)
+);
+GO
+
+CREATE INDEX IX_pb_accounts_AccountStatusId
+    ON dbo.pb_accounts (AccountStatusId);
+GO
+
+SELECT
+    c.name AS ColumnName,
+    t.name AS DataType,
+    c.max_length,
+    c.is_nullable
+FROM sys.columns c
+JOIN sys.types t
+    ON c.user_type_id = t.user_type_id
+WHERE c.object_id = OBJECT_ID(N'dbo.pb_accounts')
+ORDER BY c.column_id;
+GO
+
+SELECT
+    fk.name AS ForeignKeyName,
+    OBJECT_NAME(fk.parent_object_id) AS ParentTable,
+    pc.name AS ParentColumn,
+    OBJECT_NAME(fk.referenced_object_id) AS ReferencedTable,
+    rc.name AS ReferencedColumn
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc
+    ON fkc.constraint_object_id = fk.object_id
+JOIN sys.columns pc
+    ON pc.object_id = fkc.parent_object_id
+   AND pc.column_id = fkc.parent_column_id
+JOIN sys.columns rc
+    ON rc.object_id = fkc.referenced_object_id
+   AND rc.column_id = fkc.referenced_column_id
+WHERE fk.parent_object_id = OBJECT_ID(N'dbo.pb_accounts')
+ORDER BY fk.name;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_membership_roles.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_membership_roles.sql
@@ -1,0 +1,80 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_memberships', N'U') IS NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_system_memberships does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_roles', N'U') IS NULL
+BEGIN
+    THROW 50002, 'Stop: dbo.pb_roles does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_membership_roles', N'U') IS NOT NULL
+BEGIN
+    THROW 50003, 'Stop: dbo.pb_system_membership_roles already exists.', 1;
+END;
+GO
+
+CREATE TABLE dbo.pb_system_membership_roles
+(
+    SystemMembershipId uniqueidentifier NOT NULL,
+    RoleId int NOT NULL,
+
+    CreatedAtUtc datetime2(3) NOT NULL
+        CONSTRAINT DF_pb_system_membership_roles_CreatedAtUtc DEFAULT sysutcdatetime(),
+
+    CONSTRAINT PK_pb_system_membership_roles
+        PRIMARY KEY CLUSTERED (SystemMembershipId, RoleId),
+
+    CONSTRAINT FK_pb_system_membership_roles_pb_system_memberships
+        FOREIGN KEY (SystemMembershipId)
+        REFERENCES dbo.pb_system_memberships (SystemMembershipId),
+
+    CONSTRAINT FK_pb_system_membership_roles_pb_roles
+        FOREIGN KEY (RoleId)
+        REFERENCES dbo.pb_roles (RoleId)
+);
+GO
+
+CREATE INDEX IX_pb_system_membership_roles_RoleId
+    ON dbo.pb_system_membership_roles (RoleId);
+GO
+
+SELECT
+    s.name AS SchemaName,
+    o.name AS ObjectName,
+    o.type_desc
+FROM sys.objects o
+JOIN sys.schemas s
+    ON s.schema_id = o.schema_id
+WHERE o.object_id = OBJECT_ID(N'dbo.pb_system_membership_roles');
+GO
+
+SELECT
+    fk.name AS ForeignKeyName,
+    OBJECT_NAME(fk.parent_object_id) AS ParentTable,
+    pc.name AS ParentColumn,
+    OBJECT_NAME(fk.referenced_object_id) AS ReferencedTable,
+    rc.name AS ReferencedColumn
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc
+    ON fkc.constraint_object_id = fk.object_id
+JOIN sys.columns pc
+    ON pc.object_id = fkc.parent_object_id
+   AND pc.column_id = fkc.parent_column_id
+JOIN sys.columns rc
+    ON rc.object_id = fkc.referenced_object_id
+   AND rc.column_id = fkc.referenced_column_id
+WHERE fk.parent_object_id = OBJECT_ID(N'dbo.pb_system_membership_roles')
+ORDER BY fk.name;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_membership_statuses.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_membership_statuses.sql
@@ -1,0 +1,90 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_membership_statuses', N'U') IS NOT NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_system_membership_statuses already exists.', 1;
+END;
+GO
+
+CREATE TABLE dbo.pb_system_membership_statuses
+(
+    MembershipStatusId int NOT NULL,
+    StatusName nvarchar(64) NOT NULL,
+    StatusDesc nvarchar(500) NOT NULL,
+    DisplayOrder int NOT NULL,
+    IsActive bit NOT NULL
+        CONSTRAINT DF_pb_system_membership_statuses_IsActive DEFAULT (1),
+
+    CONSTRAINT PK_pb_system_membership_statuses
+        PRIMARY KEY CLUSTERED (MembershipStatusId),
+
+    CONSTRAINT UQ_pb_system_membership_statuses_StatusName
+        UNIQUE (StatusName),
+
+    CONSTRAINT CK_pb_system_membership_statuses_DisplayOrder_Positive
+        CHECK (DisplayOrder > 0)
+);
+GO
+
+INSERT INTO dbo.pb_system_membership_statuses
+(
+    MembershipStatusId,
+    StatusName,
+    StatusDesc,
+    DisplayOrder,
+    IsActive
+)
+VALUES
+(
+    1,
+    N'Active',
+    N'Membership is active and currently grants system access.',
+    10,
+    1
+),
+(
+    2,
+    N'Invited',
+    N'Membership invitation has been sent but has not been accepted yet.',
+    20,
+    1
+),
+(
+    3,
+    N'Suspended',
+    N'Membership is temporarily disabled and does not currently grant access.',
+    30,
+    1
+),
+(
+    4,
+    N'Revoked',
+    N'Membership has been revoked by an authorized account and no longer grants access.',
+    40,
+    1
+),
+(
+    5,
+    N'Left',
+    N'Membership was ended by the member leaving the system.',
+    50,
+    1
+);
+GO
+
+SELECT
+    MembershipStatusId,
+    StatusName,
+    StatusDesc,
+    DisplayOrder,
+    IsActive
+FROM dbo.pb_system_membership_statuses
+ORDER BY DisplayOrder;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_memberships.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/create_pb_system_memberships.sql
@@ -1,0 +1,75 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_system_memberships', N'U') IS NOT NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_system_memberships already exists.', 1;
+END;
+GO
+
+CREATE TABLE dbo.pb_system_memberships
+(
+    SystemMembershipId uniqueidentifier NOT NULL
+        CONSTRAINT DF_pb_system_memberships_SystemMembershipId DEFAULT newsequentialid(),
+
+    AccountId uniqueidentifier NOT NULL,
+    SystemId uniqueidentifier NOT NULL,
+    RoleId int NOT NULL,
+    MembershipStatusId int NOT NULL,
+
+    CreatedAtUtc datetime2(3) NOT NULL
+        CONSTRAINT DF_pb_system_memberships_CreatedAtUtc DEFAULT sysutcdatetime(),
+
+    UpdatedAtUtc datetime2(3) NULL,
+
+    CONSTRAINT PK_pb_system_memberships
+        PRIMARY KEY CLUSTERED (SystemMembershipId),
+
+    CONSTRAINT FK_pb_system_memberships_pb_systems
+        FOREIGN KEY (SystemId)
+        REFERENCES dbo.pb_systems (SystemId),
+
+    CONSTRAINT FK_pb_system_memberships_pb_roles
+        FOREIGN KEY (RoleId)
+        REFERENCES dbo.pb_roles (RoleId)
+);
+GO
+
+CREATE INDEX IX_pb_system_memberships_AccountId
+    ON dbo.pb_system_memberships (AccountId);
+GO
+
+CREATE INDEX IX_pb_system_memberships_SystemId
+    ON dbo.pb_system_memberships (SystemId);
+GO
+
+CREATE INDEX IX_pb_system_memberships_RoleId
+    ON dbo.pb_system_memberships (RoleId);
+GO
+
+SELECT
+    c.name AS ColumnName,
+    t.name AS DataType,
+    c.max_length,
+    c.is_nullable
+FROM sys.columns c
+JOIN sys.types t
+    ON c.user_type_id = t.user_type_id
+WHERE c.object_id = OBJECT_ID(N'dbo.pb_system_memberships')
+ORDER BY c.column_id;
+GO
+
+SELECT
+    fk.name AS ForeignKeyName,
+    OBJECT_NAME(fk.parent_object_id) AS ParentTable,
+    OBJECT_NAME(fk.referenced_object_id) AS ReferencedTable
+FROM sys.foreign_keys fk
+WHERE fk.parent_object_id = OBJECT_ID(N'dbo.pb_system_memberships')
+ORDER BY fk.name;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_account_row.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_account_row.sql
@@ -1,0 +1,60 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_accounts
+    WHERE AccountId = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001'
+       OR Email = N'demo@thepluralbridge.local'
+)
+BEGIN
+    THROW 50001, 'Stop: demo account already exists by AccountId or Email.', 1;
+END;
+GO
+
+INSERT INTO dbo.pb_accounts
+(
+    AccountId,
+    Email,
+    DisplayName,
+    AccountStatusId,
+    CreatedAtUtc,
+    UpdatedAtUtc
+)
+SELECT
+    '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001',
+    N'demo@thepluralbridge.local',
+    N'PluralBridge Demo Account',
+    s.AccountStatusId,
+    sysutcdatetime(),
+    NULL
+FROM dbo.pb_account_statuses s
+WHERE s.StatusName = N'Active';
+GO
+
+IF @@ROWCOUNT <> 1
+BEGIN
+    THROW 50002, 'Stop: demo account insert did not insert exactly one row.', 1;
+END;
+GO
+
+SELECT
+    a.AccountId,
+    a.Email,
+    a.DisplayName,
+    a.AccountStatusId,
+    s.StatusName,
+    a.CreatedAtUtc,
+    a.UpdatedAtUtc
+FROM dbo.pb_accounts a
+JOIN dbo.pb_account_statuses s
+    ON s.AccountStatusId = a.AccountStatusId
+WHERE a.AccountId = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001';
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_owner_membership_role.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_owner_membership_role.sql
@@ -1,0 +1,73 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+
+DECLARE @DemoSystemMembershipId uniqueidentifier = '7f7f0d8c-08d4-42df-9f0a-8db13d2d0009';
+DECLARE @OwnerRoleId int;
+DECLARE @InsertedRowCount int;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships
+    WHERE SystemMembershipId = @DemoSystemMembershipId
+)
+BEGIN
+    THROW 50001, 'Stop: demo system membership row does not exist.', 1;
+END;
+
+SELECT @OwnerRoleId = RoleId
+FROM dbo.pb_roles
+WHERE RoleName = N'Owner';
+
+IF @OwnerRoleId IS NULL
+BEGIN
+    THROW 50002, 'Stop: Owner role does not exist.', 1;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_membership_roles
+    WHERE SystemMembershipId = @DemoSystemMembershipId
+      AND RoleId = @OwnerRoleId
+)
+BEGIN
+    THROW 50003, 'Stop: demo system membership already has Owner role.', 1;
+END;
+
+INSERT INTO dbo.pb_system_membership_roles
+(
+    SystemMembershipId,
+    RoleId,
+    CreatedAtUtc
+)
+VALUES
+(
+    @DemoSystemMembershipId,
+    @OwnerRoleId,
+    sysutcdatetime()
+);
+
+SET @InsertedRowCount = @@ROWCOUNT;
+
+IF @InsertedRowCount <> 1
+BEGIN
+    THROW 50004, 'Stop: Owner role assignment insert did not insert exactly one row.', 1;
+END;
+
+SELECT
+    smr.SystemMembershipId,
+    smr.RoleId,
+    r.RoleName,
+    smr.CreatedAtUtc
+FROM dbo.pb_system_membership_roles smr
+JOIN dbo.pb_roles r
+    ON r.RoleId = smr.RoleId
+WHERE smr.SystemMembershipId = @DemoSystemMembershipId
+ORDER BY r.DisplayOrder;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_system_membership.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/insert_demo_system_membership.sql
@@ -1,0 +1,99 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+DECLARE @DemoAccountId uniqueidentifier = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001';
+DECLARE @DemoSystemMembershipId uniqueidentifier = '7f7f0d8c-08d4-42df-9f0a-8db13d2d0009';
+DECLARE @DemoSystemId uniqueidentifier;
+DECLARE @ActiveMembershipStatusId int;
+DECLARE @SystemCount int;
+DECLARE @InsertedRowCount int;
+
+SELECT @SystemCount = COUNT(*)
+FROM dbo.pb_systems;
+
+IF @SystemCount <> 1
+BEGIN
+    THROW 50001, 'Stop: expected exactly one demo system row in dbo.pb_systems.', 1;
+END;
+
+SELECT @DemoSystemId = SystemId
+FROM dbo.pb_systems;
+
+SELECT @ActiveMembershipStatusId = MembershipStatusId
+FROM dbo.pb_system_membership_statuses
+WHERE StatusName = N'Active';
+
+IF @ActiveMembershipStatusId IS NULL
+BEGIN
+    THROW 50002, 'Stop: Active membership status does not exist.', 1;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships
+    WHERE SystemMembershipId = @DemoSystemMembershipId
+)
+BEGIN
+    THROW 50003, 'Stop: demo SystemMembershipId already exists.', 1;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships
+    WHERE AccountId = @DemoAccountId
+      AND SystemId = @DemoSystemId
+)
+BEGIN
+    THROW 50004, 'Stop: demo account already has a membership row for the demo system.', 1;
+END;
+
+INSERT INTO dbo.pb_system_memberships
+(
+    SystemMembershipId,
+    AccountId,
+    SystemId,
+    MembershipStatusId,
+    CreatedAtUtc,
+    UpdatedAtUtc
+)
+VALUES
+(
+    @DemoSystemMembershipId,
+    @DemoAccountId,
+    @DemoSystemId,
+    @ActiveMembershipStatusId,
+    sysutcdatetime(),
+    NULL
+);
+
+SET @InsertedRowCount = @@ROWCOUNT;
+
+IF @InsertedRowCount <> 1
+BEGIN
+    THROW 50005, 'Stop: demo membership insert did not insert exactly one row.', 1;
+END;
+
+SELECT
+    sm.SystemMembershipId,
+    sm.AccountId,
+    a.Email,
+    sm.SystemId,
+    sm.MembershipStatusId,
+    ms.StatusName AS MembershipStatusName,
+    sm.CreatedAtUtc,
+    sm.UpdatedAtUtc
+FROM dbo.pb_system_memberships sm
+JOIN dbo.pb_accounts a
+    ON a.AccountId = sm.AccountId
+JOIN dbo.pb_system_membership_statuses ms
+    ON ms.MembershipStatusId = sm.MembershipStatusId
+WHERE sm.SystemMembershipId = @DemoSystemMembershipId;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/insert_owner_role_assignment.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/insert_owner_role_assignment.sql
@@ -1,0 +1,74 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+DECLARE @DemoSystemMembershipId uniqueidentifier = '7f7f0d8c-08d4-42df-9f0a-8db13d2d0009';
+DECLARE @OwnerRoleId int;
+DECLARE @InsertedRowCount int;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships
+    WHERE SystemMembershipId = @DemoSystemMembershipId
+)
+BEGIN
+    THROW 50001, 'Stop: demo system membership row does not exist.', 1;
+END;
+
+SELECT @OwnerRoleId = RoleId
+FROM dbo.pb_roles
+WHERE RoleName = N'Owner';
+
+IF @OwnerRoleId IS NULL
+BEGIN
+    THROW 50002, 'Stop: Owner role does not exist.', 1;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_membership_roles
+    WHERE SystemMembershipId = @DemoSystemMembershipId
+      AND RoleId = @OwnerRoleId
+)
+BEGIN
+    THROW 50003, 'Stop: demo system membership already has Owner role.', 1;
+END;
+
+INSERT INTO dbo.pb_system_membership_roles
+(
+    SystemMembershipId,
+    RoleId,
+    CreatedAtUtc
+)
+VALUES
+(
+    @DemoSystemMembershipId,
+    @OwnerRoleId,
+    sysutcdatetime()
+);
+
+SET @InsertedRowCount = @@ROWCOUNT;
+
+IF @InsertedRowCount <> 1
+BEGIN
+    THROW 50004, 'Stop: Owner role assignment insert did not insert exactly one row.', 1;
+END;
+
+SELECT
+    smr.SystemMembershipId,
+    smr.RoleId,
+    r.RoleName,
+    smr.CreatedAtUtc
+FROM dbo.pb_system_membership_roles smr
+JOIN dbo.pb_roles r
+    ON r.RoleId = smr.RoleId
+WHERE smr.SystemMembershipId = @DemoSystemMembershipId
+ORDER BY r.DisplayOrder;
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/seed_demo_account.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/seed_demo_account.sql
@@ -1,0 +1,66 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_accounts', N'U') IS NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_accounts does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_account_statuses', N'U') IS NULL
+BEGIN
+    THROW 50002, 'Stop: dbo.pb_account_statuses does not exist.', 1;
+END;
+GO
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_accounts
+    WHERE AccountId = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001'
+       OR Email = N'demo@thepluralbridge.local'
+)
+BEGIN
+    THROW 50003, 'Stop: demo account already exists by AccountId or Email.', 1;
+END;
+GO
+
+INSERT INTO dbo.pb_accounts
+(
+    AccountId,
+    Email,
+    DisplayName,
+    AccountStatusId,
+    CreatedAtUtc,
+    UpdatedAtUtc
+)
+SELECT
+    '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001',
+    N'demo@thepluralbridge.local',
+    N'PluralBridge Demo Account',
+    s.AccountStatusId,
+    sysutcdatetime(),
+    NULL
+FROM dbo.pb_account_statuses s
+WHERE s.StatusName = N'Active';
+GO
+
+SELECT
+    a.AccountId,
+    a.Email,
+    a.DisplayName,
+    a.AccountStatusId,
+    s.StatusName,
+    a.CreatedAtUtc,
+    a.UpdatedAtUtc
+FROM dbo.pb_accounts a
+JOIN dbo.pb_account_statuses s
+    ON s.AccountStatusId = a.AccountStatusId
+WHERE a.AccountId = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001';
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/verify_account_demo_prereqs.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/verify_account_demo_prereqs.sql
@@ -1,0 +1,58 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_accounts', N'U') IS NULL
+BEGIN
+    THROW 50001, 'Stop: dbo.pb_accounts does not exist.', 1;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.pb_account_statuses', N'U') IS NULL
+BEGIN
+    THROW 50002, 'Stop: dbo.pb_account_statuses does not exist.', 1;
+END;
+GO
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_account_statuses
+    WHERE StatusName = N'Active'
+)
+BEGIN
+    THROW 50003, 'Stop: Active account status does not exist.', 1;
+END;
+GO
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_accounts
+    WHERE Email = N'demo@thepluralbridge.local'
+)
+BEGIN
+    THROW 50004, 'Stop: demo account email already exists in dbo.pb_accounts.', 1;
+END;
+GO
+
+SELECT
+    s.AccountStatusId,
+    s.StatusName,
+    s.StatusDesc,
+    s.DisplayOrder,
+    s.IsActive
+FROM dbo.pb_account_statuses s
+WHERE s.StatusName = N'Active';
+GO
+
+SELECT
+    COUNT(*) AS ExistingDemoAccountRows
+FROM dbo.pb_accounts
+WHERE Email = N'demo@thepluralbridge.local';
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/verify_demo_membership_path.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/verify_demo_membership_path.sql
@@ -1,0 +1,50 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+
+DECLARE @DemoAccountId uniqueidentifier = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001';
+DECLARE @DemoSystemMembershipId uniqueidentifier = '7f7f0d8c-08d4-42df-9f0a-8db13d2d0009';
+
+SELECT
+    a.AccountId,
+    a.Email,
+    a.DisplayName,
+    sm.SystemMembershipId,
+    sm.SystemId,
+    ms.StatusName AS MembershipStatusName,
+    r.RoleId,
+    r.RoleName
+FROM dbo.pb_accounts a
+JOIN dbo.pb_system_memberships sm
+    ON sm.AccountId = a.AccountId
+JOIN dbo.pb_system_membership_statuses ms
+    ON ms.MembershipStatusId = sm.MembershipStatusId
+JOIN dbo.pb_system_membership_roles smr
+    ON smr.SystemMembershipId = sm.SystemMembershipId
+JOIN dbo.pb_roles r
+    ON r.RoleId = smr.RoleId
+WHERE a.AccountId = @DemoAccountId
+  AND sm.SystemMembershipId = @DemoSystemMembershipId
+ORDER BY r.DisplayOrder;
+
+SELECT
+    COUNT(*) AS DemoOwnerMembershipPathCount
+FROM dbo.pb_accounts a
+JOIN dbo.pb_system_memberships sm
+    ON sm.AccountId = a.AccountId
+JOIN dbo.pb_system_membership_statuses ms
+    ON ms.MembershipStatusId = sm.MembershipStatusId
+JOIN dbo.pb_system_membership_roles smr
+    ON smr.SystemMembershipId = sm.SystemMembershipId
+JOIN dbo.pb_roles r
+    ON r.RoleId = smr.RoleId
+WHERE a.AccountId = @DemoAccountId
+  AND a.Email = N'demo@thepluralbridge.local'
+  AND sm.SystemMembershipId = @DemoSystemMembershipId
+  AND ms.StatusName = N'Active'
+  AND r.RoleName = N'Owner';
+GO

--- a/scripts/sqlserver/chap2_safe_spine/scripts/verify_demo_membership_prereqs.sql
+++ b/scripts/sqlserver/chap2_safe_spine/scripts/verify_demo_membership_prereqs.sql
@@ -1,0 +1,99 @@
+SELECT DB_NAME() AS CurrentDatabase;
+GO
+
+IF DB_NAME() <> N'PluralBridgeChap2SafeSpine'
+BEGIN
+    THROW 50000, 'Stop: set the query window database dropdown to PluralBridgeChap2SafeSpine.', 1;
+END;
+
+DECLARE @DemoAccountId uniqueidentifier = '8f3f8e4b-0d64-4b4a-9f6e-8db13d2d0001';
+DECLARE @DemoSystemId uniqueidentifier;
+DECLARE @SystemCount int;
+
+SELECT @SystemCount = COUNT(*)
+FROM dbo.pb_systems;
+
+IF @SystemCount <> 1
+BEGIN
+    THROW 50001, 'Stop: expected exactly one demo system row in dbo.pb_systems.', 1;
+END;
+
+SELECT @DemoSystemId = SystemId
+FROM dbo.pb_systems;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_accounts
+    WHERE AccountId = @DemoAccountId
+      AND Email = N'demo@thepluralbridge.local'
+)
+BEGIN
+    THROW 50002, 'Stop: demo account row does not exist.', 1;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_membership_statuses
+    WHERE StatusName = N'Active'
+)
+BEGIN
+    THROW 50003, 'Stop: Active membership status does not exist.', 1;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_roles
+    WHERE RoleName = N'Owner'
+)
+BEGIN
+    THROW 50004, 'Stop: Owner role does not exist.', 1;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_systems
+    WHERE SystemId = @DemoSystemId
+)
+BEGIN
+    THROW 50005, 'Stop: target demo system row does not exist.', 1;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM dbo.pb_system_memberships
+    WHERE AccountId = @DemoAccountId
+      AND SystemId = @DemoSystemId
+)
+BEGIN
+    THROW 50006, 'Stop: demo account already has a membership row for the demo system.', 1;
+END;
+
+SELECT
+    a.AccountId,
+    a.Email,
+    a.DisplayName,
+    s.SystemId,
+    ms.MembershipStatusId,
+    ms.StatusName AS MembershipStatusName,
+    r.RoleId,
+    r.RoleName
+FROM dbo.pb_accounts a
+CROSS JOIN dbo.pb_systems s
+CROSS JOIN dbo.pb_system_membership_statuses ms
+CROSS JOIN dbo.pb_roles r
+WHERE a.AccountId = @DemoAccountId
+  AND s.SystemId = @DemoSystemId
+  AND ms.StatusName = N'Active'
+  AND r.RoleName = N'Owner';
+
+SELECT
+    COUNT(*) AS ExistingDemoMembershipRows
+FROM dbo.pb_system_memberships
+WHERE AccountId = @DemoAccountId
+  AND SystemId = @DemoSystemId;
+GO


### PR DESCRIPTION
Adds the PB-NEXT Chapter 2 safe-spine SQL foundation and demo account/membership seed scripts.

Included:

* Account status lookup and account table
* Role lookup and membership status lookup
* System membership table
* Multi-role membership join table
* FK coverage for account status, account membership, system membership, membership status, and role assignment
* Composite PK on membership-role assignments to prevent duplicate join rows
* Demo account seed scripts
* Demo Owner membership seed scripts
* TAG_TASKS.md update for v0.8.0 milestone

Notes:

* SQL/script foundation only.
* Runtime authorization behavior is not changed yet.
* Existing demo read-only behavior was verified before the safe-spine work.
* Simply Plural-shaped privacy bucket data remains untouched.
